### PR TITLE
4.3.0

### DIFF
--- a/src/AInq.Optional.Async/EitherAsync.Extension.Task.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.Task.cs
@@ -26,30 +26,42 @@ public static partial class EitherAsync
         /// <inheritdoc cref="Either.MaybeLeft{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TLeft>> MaybeLeft(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Maybe<TLeft>>(eitherTask.Result.MaybeLeft())
                 : AwaitMaybeLeft(eitherTask, cancellation);
+        }
 
         /// <inheritdoc cref="Either.MaybeRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TRight>> MaybeRight(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Maybe<TRight>>(eitherTask.Result.MaybeRight())
                 : AwaitMaybeRight(eitherTask, cancellation);
+        }
 
         /// <inheritdoc cref="Either.TryLeft{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<Try<TLeft>> TryLeft(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Try<TLeft>>(eitherTask.Result.TryLeft())
                 : AwaitTryLeft(eitherTask, cancellation);
+        }
 
         /// <inheritdoc cref="Either.TryRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<Try<TRight>> TryRight(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Try<TRight>>(eitherTask.Result.TryRight())
                 : AwaitTryRight(eitherTask, cancellation);
+        }
 
 #endregion
 
@@ -59,19 +71,25 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeft<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRight>>(
-                    eitherTask.Result.SelectLeft(leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))))
-                : AwaitSelectLeft(eitherTask, leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRight>>(eitherTask.Result.SelectLeft(leftSelector))
+                : AwaitSelectLeft(eitherTask, leftSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRight}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeft<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRight>> leftSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRight>>(
-                    eitherTask.Result.SelectLeft(leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))))
-                : AwaitSelectLeft(eitherTask, leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRight>>(eitherTask.Result.SelectLeft(leftSelector))
+                : AwaitSelectLeft(eitherTask, leftSelector, cancellation);
+        }
 
 #endregion
 
@@ -81,19 +99,25 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRight<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeft, TRightResult>>(
-                    eitherTask.Result.SelectRight(rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelectRight(eitherTask, rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeft, TRightResult>>(eitherTask.Result.SelectRight(rightSelector))
+                : AwaitSelectRight(eitherTask, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,Either{TLeft,TRightResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRight<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeft, TRightResult>> rightSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeft, TRightResult>>(
-                    eitherTask.Result.SelectRight(rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelectRight(eitherTask, rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeft, TRightResult>>(eitherTask.Result.SelectRight(rightSelector))
+                : AwaitSelectRight(eitherTask, rightSelector, cancellation);
+        }
 
 #endregion
 
@@ -104,28 +128,28 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeftResult, TRightResult>> Select<TLeftResult, TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherTask,
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherTask, leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRightResult>> Select<TLeftResult, TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherTask,
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherTask, leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -133,14 +157,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherTask,
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherTask, leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -148,14 +172,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherTask,
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherTask, leftSelector, rightSelector, cancellation);
+        }
 
 #endregion
 
@@ -166,18 +190,26 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectLeftAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)), cancellation)
-                : AwaitSelectLeft(eitherTask, asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectLeftAsync(asyncLeftSelector, cancellation)
+                : AwaitSelectLeft(eitherTask, asyncLeftSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRight}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRight>>> asyncLeftSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectLeftAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)), cancellation)
-                : AwaitSelectLeft(eitherTask, asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectLeftAsync(asyncLeftSelector, cancellation)
+                : AwaitSelectLeft(eitherTask, asyncLeftSelector, cancellation);
+        }
 
 #endregion
 
@@ -188,18 +220,26 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectRightAsync(asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)), cancellation)
-                : AwaitSelectRight(eitherTask, asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectRightAsync(asyncRightSelector, cancellation)
+                : AwaitSelectRight(eitherTask, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,Either{TLeft,TRightResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeft, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectRightAsync(asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)), cancellation)
-                : AwaitSelectRight(eitherTask, asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectRightAsync(asyncRightSelector, cancellation)
+                : AwaitSelectRight(eitherTask, asyncRightSelector, cancellation);
+        }
 
 #endregion
 
@@ -211,14 +251,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherTask,
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherTask, asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
@@ -226,14 +266,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherTask,
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherTask, asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -241,14 +281,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherTask,
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherTask, asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -256,14 +296,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherTask,
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherTask, asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
 #endregion
 
@@ -272,75 +312,92 @@ public static partial class EitherAsync
         /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight})" />
         [PublicAPI, Pure]
         public ValueTask<TLeft?> LeftOrDefault(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<TLeft?>(eitherTask.Result.LeftOrDefault())
                 : AwaitLeftOrDefault(eitherTask, cancellation);
+        }
 
         /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight},TLeft)" />
         [PublicAPI, Pure]
         public ValueTask<TLeft> LeftOrDefault([NoEnumeration] TLeft defaultValue, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<TLeft>(eitherTask.Result.LeftOrDefault(defaultValue))
                 : AwaitLeftOrDefault(eitherTask, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TLeft})" />
         [PublicAPI, Pure]
         public ValueTask<TLeft> LeftOrDefault([InstantHandle(RequireAwait = true)] Func<TLeft> defaultGenerator,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TLeft>(eitherTask.Result.LeftOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitLeftOrDefault(eitherTask, defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)), cancellation);
-
-        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight})" />
-        [PublicAPI, Pure]
-        public ValueTask<TRight?> RightOrDefault(CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TRight?>(eitherTask.Result.RightOrDefault())
-                : AwaitRightOrDefault(eitherTask, cancellation);
-
-        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},TRight)" />
-        [PublicAPI, Pure]
-        public ValueTask<TRight> RightOrDefault([NoEnumeration] TRight defaultValue, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TRight>(eitherTask.Result.RightOrDefault(defaultValue))
-                : AwaitRightOrDefault(eitherTask, defaultValue, cancellation);
-
-        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TRight})" />
-        [PublicAPI, Pure]
-        public ValueTask<TRight> RightOrDefault([InstantHandle(RequireAwait = true)] Func<TRight> defaultGenerator,
-            CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TRight>(
-                    eitherTask.Result.RightOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitRightOrDefault(eitherTask, defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)), cancellation);
-
-#endregion
-
-#region ValueOrDefaultAsync
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TLeft>(eitherTask.Result.LeftOrDefault(defaultGenerator))
+                : AwaitLeftOrDefault(eitherTask, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TLeft})" />
         [PublicAPI, Pure]
         public ValueTask<TLeft> LeftOrDefaultAsync(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TLeft>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.LeftOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitLeftOrDefault(eitherTask,
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.LeftOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitLeftOrDefault(eitherTask, asyncDefaultGenerator, cancellation);
+        }
+
+        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight})" />
+        [PublicAPI, Pure]
+        public ValueTask<TRight?> RightOrDefault(CancellationToken cancellation = default)
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TRight?>(eitherTask.Result.RightOrDefault())
+                : AwaitRightOrDefault(eitherTask, cancellation);
+        }
+
+        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},TRight)" />
+        [PublicAPI, Pure]
+        public ValueTask<TRight> RightOrDefault([NoEnumeration] TRight defaultValue, CancellationToken cancellation = default)
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TRight>(eitherTask.Result.RightOrDefault(defaultValue))
+                : AwaitRightOrDefault(eitherTask, defaultValue, cancellation);
+        }
+
+        /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TRight})" />
+        [PublicAPI, Pure]
+        public ValueTask<TRight> RightOrDefault([InstantHandle(RequireAwait = true)] Func<TRight> defaultGenerator,
+            CancellationToken cancellation = default)
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TRight>(eitherTask.Result.RightOrDefault(defaultGenerator))
+                : AwaitRightOrDefault(eitherTask, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TRight})" />
         [PublicAPI, Pure]
         public ValueTask<TRight> RightOrDefaultAsync(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TRight>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.RightOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitRightOrDefault(eitherTask,
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.RightOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitRightOrDefault(eitherTask, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -349,29 +406,38 @@ public static partial class EitherAsync
         /// <inheritdoc cref="Either.ToLeft{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TLeft> ToLeft([InstantHandle(RequireAwait = true)] Func<TRight, TLeft> rightToLeft, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TLeft>(eitherTask.Result.ToLeft(rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft))))
-                : AwaitToLeft(eitherTask, rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TLeft>(eitherTask.Result.ToLeft(rightToLeft))
+                : AwaitToLeft(eitherTask, rightToLeft, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TRight> ToRight([InstantHandle(RequireAwait = true)] Func<TLeft, TRight> leftToRight,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TRight>(eitherTask.Result.ToRight(leftToRight ?? throw new ArgumentNullException(nameof(leftToRight))))
-                : AwaitToRight(eitherTask, leftToRight ?? throw new ArgumentNullException(nameof(leftToRight)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftToRight ?? throw new ArgumentNullException(nameof(leftToRight));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TRight>(eitherTask.Result.ToRight(leftToRight))
+                : AwaitToRight(eitherTask, leftToRight, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToValue{TLeft,TRight,TResult}" />
         [PublicAPI, Pure]
         public ValueTask<TResult> ToValue<TResult>([InstantHandle(RequireAwait = true)] Func<TLeft, TResult> fromLeft,
             [InstantHandle(RequireAwait = true)] Func<TRight, TResult> fromRight, CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult>(eitherTask.Result.ToValue(fromLeft ?? throw new ArgumentNullException(nameof(fromLeft)),
-                    fromRight ?? throw new ArgumentNullException(nameof(fromRight))))
-                : AwaitToValue(eitherTask,
-                    fromLeft ?? throw new ArgumentNullException(nameof(fromLeft)),
-                    fromRight ?? throw new ArgumentNullException(nameof(fromRight)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = fromLeft ?? throw new ArgumentNullException(nameof(fromLeft));
+            _ = fromRight ?? throw new ArgumentNullException(nameof(fromRight));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult>(eitherTask.Result.ToValue(fromLeft, fromRight))
+                : AwaitToValue(eitherTask, fromLeft, fromRight, cancellation);
+        }
 
 #endregion
 
@@ -381,17 +447,25 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<TLeft> ToLeftAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TLeft>> asyncRightToLeft,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.ToLeftAsync(asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft)), cancellation)
-                : AwaitToLeft(eitherTask, asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.ToLeftAsync(asyncRightToLeft, cancellation)
+                : AwaitToLeft(eitherTask, asyncRightToLeft, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TRight> ToRightAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TRight>> asyncLeftToRight,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.ToRightAsync(asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight)), cancellation)
-                : AwaitToRight(eitherTask, asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight)), cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.ToRightAsync(asyncLeftToRight, cancellation)
+                : AwaitToRight(eitherTask, asyncLeftToRight, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToValue{TLeft,TRight,TResult}" />
         [PublicAPI, Pure]
@@ -399,14 +473,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TResult>> asyncFromLeft,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TResult>> asyncFromRight,
             CancellationToken cancellation = default)
-            => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
-                ? eitherTask.Result.ToValueAsync(asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft)),
-                    asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight)),
-                    cancellation)
-                : AwaitToValue(eitherTask,
-                    asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft)),
-                    asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight)),
-                    cancellation);
+        {
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft));
+            _ = asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight));
+            return eitherTask.Status is TaskStatus.RanToCompletion
+                ? eitherTask.Result.ToValueAsync(asyncFromLeft, asyncFromRight, cancellation)
+                : AwaitToValue(eitherTask, asyncFromLeft, asyncFromRight, cancellation);
+        }
 
 #endregion
 
@@ -417,13 +491,11 @@ public static partial class EitherAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<TLeft> leftAction,
             [InstantHandle(RequireAwait = true)] Action<TRight> rightAction, CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(eitherTask,
-                    leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                    rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                    cancellation);
-            eitherTask.Result.Do(leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                rightAction ?? throw new ArgumentNullException(nameof(rightAction)));
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(eitherTask, leftAction, rightAction, cancellation);
+            eitherTask.Result.Do(leftAction, rightAction);
             return default;
         }
 
@@ -431,9 +503,10 @@ public static partial class EitherAsync
         [PublicAPI]
         public ValueTask DoLeft([InstantHandle(RequireAwait = true)] Action<TLeft> leftAction, CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoLeft(eitherTask, leftAction ?? throw new ArgumentNullException(nameof(leftAction)), cancellation);
-            eitherTask.Result.DoLeft(leftAction ?? throw new ArgumentNullException(nameof(leftAction)));
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDoLeft(eitherTask, leftAction, cancellation);
+            eitherTask.Result.DoLeft(leftAction);
             return default;
         }
 
@@ -441,9 +514,10 @@ public static partial class EitherAsync
         [PublicAPI]
         public ValueTask DoRight([InstantHandle(RequireAwait = true)] Action<TRight> rightAction, CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoRight(eitherTask, rightAction ?? throw new ArgumentNullException(nameof(rightAction)), cancellation);
-            eitherTask.Result.DoRight(rightAction ?? throw new ArgumentNullException(nameof(rightAction)));
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDoRight(eitherTask, rightAction, cancellation);
+            eitherTask.Result.DoRight(rightAction);
             return default;
         }
 
@@ -456,15 +530,11 @@ public static partial class EitherAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<TLeft, TArgument> leftAction,
             [InstantHandle(RequireAwait = true)] Action<TRight, TArgument> rightAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(eitherTask,
-                    leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                    rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                    argument,
-                    cancellation);
-            eitherTask.Result.Do(leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                argument);
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(eitherTask, leftAction, rightAction, argument, cancellation);
+            eitherTask.Result.Do(leftAction, rightAction, argument);
             return default;
         }
 
@@ -473,9 +543,10 @@ public static partial class EitherAsync
         public ValueTask DoLeft<TArgument>([InstantHandle(RequireAwait = true)] Action<TLeft, TArgument> leftAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoLeft(eitherTask, leftAction ?? throw new ArgumentNullException(nameof(leftAction)), argument, cancellation);
-            eitherTask.Result.DoLeft(leftAction ?? throw new ArgumentNullException(nameof(leftAction)), argument);
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDoLeft(eitherTask, leftAction, argument, cancellation);
+            eitherTask.Result.DoLeft(leftAction, argument);
             return default;
         }
 
@@ -484,9 +555,10 @@ public static partial class EitherAsync
         public ValueTask DoRight<TArgument>([InstantHandle(RequireAwait = true)] Action<TRight, TArgument> rightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoRight(eitherTask, rightAction ?? throw new ArgumentNullException(nameof(rightAction)), argument, cancellation);
-            eitherTask.Result.DoRight(rightAction ?? throw new ArgumentNullException(nameof(rightAction)), argument);
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (eitherTask.Status is not TaskStatus.RanToCompletion) return AwaitDoRight(eitherTask, rightAction, argument, cancellation);
+            eitherTask.Result.DoRight(rightAction, argument);
             return default;
         }
 
@@ -499,15 +571,14 @@ public static partial class EitherAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction, CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -515,12 +586,12 @@ public static partial class EitherAsync
         public async Task DoLeftAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight}" />
@@ -528,12 +599,12 @@ public static partial class EitherAsync
         public async Task DoRightAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction,
             CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -546,15 +617,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />
@@ -562,12 +632,12 @@ public static partial class EitherAsync
         public async Task DoLeftAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TLeft, TArgument, CancellationToken, Task> asyncLeftAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight,TArgument}" />
@@ -576,12 +646,12 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            var either = (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+            _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            var either = eitherTask.Status is TaskStatus.RanToCompletion
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/EitherAsync.Extension.Task.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.Task.cs
@@ -578,7 +578,7 @@ public static partial class EitherAsync
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -624,7 +624,7 @@ public static partial class EitherAsync
                 ? eitherTask.Result
                 : await eitherTask.WaitAsync(cancellation).ConfigureAwait(false);
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />

--- a/src/AInq.Optional.Async/EitherAsync.Extension.ValueTask.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.ValueTask.cs
@@ -521,7 +521,7 @@ public static partial class EitherAsync
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -564,7 +564,7 @@ public static partial class EitherAsync
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />

--- a/src/AInq.Optional.Async/EitherAsync.Extension.ValueTask.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.ValueTask.cs
@@ -59,19 +59,23 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeft<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRight>>(
-                    eitherValueTask.Result.SelectLeft(leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))))
-                : AwaitSelectLeft(eitherValueTask.AsTask(), leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)), cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRight>>(eitherValueTask.Result.SelectLeft(leftSelector))
+                : AwaitSelectLeft(eitherValueTask.AsTask(), leftSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRight}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeft<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRight>> leftSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRight>>(
-                    eitherValueTask.Result.SelectLeft(leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))))
-                : AwaitSelectLeft(eitherValueTask.AsTask(), leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)), cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRight>>(eitherValueTask.Result.SelectLeft(leftSelector))
+                : AwaitSelectLeft(eitherValueTask.AsTask(), leftSelector, cancellation);
+        }
 
 #endregion
 
@@ -81,19 +85,23 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRight<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeft, TRightResult>>(
-                    eitherValueTask.Result.SelectRight(rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelectRight(eitherValueTask.AsTask(), rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)), cancellation);
+        {
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeft, TRightResult>>(eitherValueTask.Result.SelectRight(rightSelector))
+                : AwaitSelectRight(eitherValueTask.AsTask(), rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,Either{TLeft,TRightResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRight<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeft, TRightResult>> rightSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeft, TRightResult>>(
-                    eitherValueTask.Result.SelectRight(rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelectRight(eitherValueTask.AsTask(), rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)), cancellation);
+        {
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeft, TRightResult>>(eitherValueTask.Result.SelectRight(rightSelector))
+                : AwaitSelectRight(eitherValueTask.AsTask(), rightSelector, cancellation);
+        }
 
 #endregion
 
@@ -104,28 +112,26 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeftResult, TRightResult>> Select<TLeftResult, TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherValueTask.AsTask(), leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRightResult>> Select<TLeftResult, TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, TRightResult> rightSelector, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherValueTask.AsTask(), leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -133,14 +139,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherValueTask.AsTask(), leftSelector, rightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -148,14 +153,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))))
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    leftSelector ?? throw new ArgumentNullException(nameof(leftSelector)),
-                    rightSelector ?? throw new ArgumentNullException(nameof(rightSelector)),
-                    cancellation);
+        {
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<TLeftResult, TRightResult>>(eitherValueTask.Result.Select(leftSelector, rightSelector))
+                : AwaitSelect(eitherValueTask.AsTask(), leftSelector, rightSelector, cancellation);
+        }
 
 #endregion
 
@@ -166,24 +170,24 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectLeftAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    cancellation)
-                : AwaitSelectLeft(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectLeftAsync(asyncLeftSelector, cancellation)
+                : AwaitSelectLeft(eitherValueTask.AsTask(), asyncLeftSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRight}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRight>>> asyncLeftSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectLeftAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    cancellation)
-                : AwaitSelectLeft(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectLeftAsync(asyncLeftSelector, cancellation)
+                : AwaitSelectLeft(eitherValueTask.AsTask(), asyncLeftSelector, cancellation);
+        }
 
 #endregion
 
@@ -194,24 +198,24 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectRightAsync(asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelectRight(eitherValueTask.AsTask(),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectRightAsync(asyncRightSelector, cancellation)
+                : AwaitSelectRight(eitherValueTask.AsTask(), asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,Either{TLeft,TRightResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeft, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectRightAsync(asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelectRight(eitherValueTask.AsTask(),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectRightAsync(asyncRightSelector, cancellation)
+                : AwaitSelectRight(eitherValueTask.AsTask(), asyncRightSelector, cancellation);
+        }
 
 #endregion
 
@@ -223,14 +227,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherValueTask.AsTask(), asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
@@ -238,14 +241,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherValueTask.AsTask(), asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -253,14 +255,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherValueTask.AsTask(), asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -268,14 +269,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation)
-                : AwaitSelect(eitherValueTask.AsTask(),
-                    asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector)),
-                    asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector)),
-                    cancellation);
+        {
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.SelectAsync(asyncLeftSelector, asyncRightSelector, cancellation)
+                : AwaitSelect(eitherValueTask.AsTask(), asyncLeftSelector, asyncRightSelector, cancellation);
+        }
 
 #endregion
 
@@ -299,12 +299,24 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<TLeft> LeftOrDefault([InstantHandle(RequireAwait = true)] Func<TLeft> defaultGenerator,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TLeft>(
-                    eitherValueTask.Result.LeftOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitLeftOrDefault(eitherValueTask.AsTask(),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TLeft>(eitherValueTask.Result.LeftOrDefault(defaultGenerator))
+                : AwaitLeftOrDefault(eitherValueTask.AsTask(), defaultGenerator, cancellation);
+        }
+
+        /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TLeft})" />
+        [PublicAPI, Pure]
+        public ValueTask<TLeft> LeftOrDefaultAsync(
+            [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TLeft>> asyncDefaultGenerator,
+            CancellationToken cancellation = default)
+        {
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.LeftOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitLeftOrDefault(eitherValueTask.AsTask(), asyncDefaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight})" />
         [PublicAPI, Pure]
@@ -324,40 +336,24 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<TRight> RightOrDefault([InstantHandle(RequireAwait = true)] Func<TRight> defaultGenerator,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TRight>(
-                    eitherValueTask.Result.RightOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitRightOrDefault(eitherValueTask.AsTask(),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
-
-#endregion
-
-#region ValueOrDefaultAsync
-
-        /// <inheritdoc cref="Either.LeftOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TLeft})" />
-        [PublicAPI, Pure]
-        public ValueTask<TLeft> LeftOrDefaultAsync(
-            [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TLeft>> asyncDefaultGenerator,
-            CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.LeftOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitLeftOrDefault(eitherValueTask.AsTask(),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TRight>(eitherValueTask.Result.RightOrDefault(defaultGenerator))
+                : AwaitRightOrDefault(eitherValueTask.AsTask(), defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TRight})" />
         [PublicAPI, Pure]
         public ValueTask<TRight> RightOrDefaultAsync(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TRight>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.RightOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitRightOrDefault(eitherValueTask.AsTask(),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.RightOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitRightOrDefault(eitherValueTask.AsTask(), asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -366,29 +362,35 @@ public static partial class EitherAsync
         /// <inheritdoc cref="Either.ToLeft{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TLeft> ToLeft([InstantHandle(RequireAwait = true)] Func<TRight, TLeft> rightToLeft, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TLeft>(eitherValueTask.Result.ToLeft(rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft))))
-                : AwaitToLeft(eitherValueTask.AsTask(), rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft)), cancellation);
+        {
+            _ = rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TLeft>(eitherValueTask.Result.ToLeft(rightToLeft))
+                : AwaitToLeft(eitherValueTask.AsTask(), rightToLeft, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TRight> ToRight([InstantHandle(RequireAwait = true)] Func<TLeft, TRight> leftToRight,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TRight>(eitherValueTask.Result.ToRight(leftToRight ?? throw new ArgumentNullException(nameof(leftToRight))))
-                : AwaitToRight(eitherValueTask.AsTask(), leftToRight ?? throw new ArgumentNullException(nameof(leftToRight)), cancellation);
+        {
+            _ = leftToRight ?? throw new ArgumentNullException(nameof(leftToRight));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TRight>(eitherValueTask.Result.ToRight(leftToRight))
+                : AwaitToRight(eitherValueTask.AsTask(), leftToRight, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToValue{TLeft,TRight,TResult}" />
         [PublicAPI, Pure]
         public ValueTask<TResult> ToValue<TResult>([InstantHandle(RequireAwait = true)] Func<TLeft, TResult> fromLeft,
             [InstantHandle(RequireAwait = true)] Func<TRight, TResult> fromRight, CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult>(eitherValueTask.Result.ToValue(fromLeft ?? throw new ArgumentNullException(nameof(fromLeft)),
-                    fromRight ?? throw new ArgumentNullException(nameof(fromRight))))
-                : AwaitToValue(eitherValueTask.AsTask(),
-                    fromLeft ?? throw new ArgumentNullException(nameof(fromLeft)),
-                    fromRight ?? throw new ArgumentNullException(nameof(fromRight)),
-                    cancellation);
+        {
+            _ = fromLeft ?? throw new ArgumentNullException(nameof(fromLeft));
+            _ = fromRight ?? throw new ArgumentNullException(nameof(fromRight));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult>(eitherValueTask.Result.ToValue(fromLeft, fromRight))
+                : AwaitToValue(eitherValueTask.AsTask(), fromLeft, fromRight, cancellation);
+        }
 
 #endregion
 
@@ -398,17 +400,23 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<TLeft> ToLeftAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TLeft>> asyncRightToLeft,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.ToLeftAsync(asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft)), cancellation)
-                : AwaitToLeft(eitherValueTask.AsTask(), asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft)), cancellation);
+        {
+            _ = asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.ToLeftAsync(asyncRightToLeft, cancellation)
+                : AwaitToLeft(eitherValueTask.AsTask(), asyncRightToLeft, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TRight> ToRightAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TRight>> asyncLeftToRight,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.ToRightAsync(asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight)), cancellation)
-                : AwaitToRight(eitherValueTask.AsTask(), asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight)), cancellation);
+        {
+            _ = asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.ToRightAsync(asyncLeftToRight, cancellation)
+                : AwaitToRight(eitherValueTask.AsTask(), asyncLeftToRight, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToValue{TLeft,TRight,TResult}" />
         [PublicAPI, Pure]
@@ -416,14 +424,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TResult>> asyncFromLeft,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TResult>> asyncFromRight,
             CancellationToken cancellation = default)
-            => eitherValueTask.IsCompletedSuccessfully
-                ? eitherValueTask.Result.ToValueAsync(asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft)),
-                    asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight)),
-                    cancellation)
-                : AwaitToValue(eitherValueTask.AsTask(),
-                    asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft)),
-                    asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight)),
-                    cancellation);
+        {
+            _ = asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft));
+            _ = asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight));
+            return eitherValueTask.IsCompletedSuccessfully
+                ? eitherValueTask.Result.ToValueAsync(asyncFromLeft, asyncFromRight, cancellation)
+                : AwaitToValue(eitherValueTask.AsTask(), asyncFromLeft, asyncFromRight, cancellation);
+        }
 
 #endregion
 
@@ -434,13 +441,10 @@ public static partial class EitherAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<TLeft> leftAction,
             [InstantHandle(RequireAwait = true)] Action<TRight> rightAction, CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDo(eitherValueTask.AsTask(),
-                    leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                    rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                    cancellation);
-            eitherValueTask.Result.Do(leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                rightAction ?? throw new ArgumentNullException(nameof(rightAction)));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDo(eitherValueTask.AsTask(), leftAction, rightAction, cancellation);
+            eitherValueTask.Result.Do(leftAction, rightAction);
             return default;
         }
 
@@ -448,9 +452,9 @@ public static partial class EitherAsync
         [PublicAPI]
         public ValueTask DoLeft([InstantHandle(RequireAwait = true)] Action<TLeft> leftAction, CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDoLeft(eitherValueTask.AsTask(), leftAction ?? throw new ArgumentNullException(nameof(leftAction)), cancellation);
-            eitherValueTask.Result.DoLeft(leftAction ?? throw new ArgumentNullException(nameof(leftAction)));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDoLeft(eitherValueTask.AsTask(), leftAction, cancellation);
+            eitherValueTask.Result.DoLeft(leftAction);
             return default;
         }
 
@@ -458,9 +462,9 @@ public static partial class EitherAsync
         [PublicAPI]
         public ValueTask DoRight([InstantHandle(RequireAwait = true)] Action<TRight> rightAction, CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDoRight(eitherValueTask.AsTask(), rightAction ?? throw new ArgumentNullException(nameof(rightAction)), cancellation);
-            eitherValueTask.Result.DoRight(rightAction ?? throw new ArgumentNullException(nameof(rightAction)));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDoRight(eitherValueTask.AsTask(), rightAction, cancellation);
+            eitherValueTask.Result.DoRight(rightAction);
             return default;
         }
 
@@ -473,15 +477,10 @@ public static partial class EitherAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<TLeft, TArgument> leftAction,
             [InstantHandle(RequireAwait = true)] Action<TRight, TArgument> rightAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDo(eitherValueTask.AsTask(),
-                    leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                    rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                    argument,
-                    cancellation);
-            eitherValueTask.Result.Do(leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                argument);
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDo(eitherValueTask.AsTask(), leftAction, rightAction, argument, cancellation);
+            eitherValueTask.Result.Do(leftAction, rightAction, argument);
             return default;
         }
 
@@ -490,12 +489,9 @@ public static partial class EitherAsync
         public ValueTask DoLeft<TArgument>([InstantHandle(RequireAwait = true)] Action<TLeft, TArgument> leftAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDoLeft(eitherValueTask.AsTask(),
-                    leftAction ?? throw new ArgumentNullException(nameof(leftAction)),
-                    argument,
-                    cancellation);
-            eitherValueTask.Result.DoLeft(leftAction ?? throw new ArgumentNullException(nameof(leftAction)), argument);
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDoLeft(eitherValueTask.AsTask(), leftAction, argument, cancellation);
+            eitherValueTask.Result.DoLeft(leftAction, argument);
             return default;
         }
 
@@ -504,12 +500,9 @@ public static partial class EitherAsync
         public ValueTask DoRight<TArgument>([InstantHandle(RequireAwait = true)] Action<TRight, TArgument> rightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if (!eitherValueTask.IsCompletedSuccessfully)
-                return AwaitDoRight(eitherValueTask.AsTask(),
-                    rightAction ?? throw new ArgumentNullException(nameof(rightAction)),
-                    argument,
-                    cancellation);
-            eitherValueTask.Result.DoRight(rightAction ?? throw new ArgumentNullException(nameof(rightAction)), argument);
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (!eitherValueTask.IsCompletedSuccessfully) return AwaitDoRight(eitherValueTask.AsTask(), rightAction, argument, cancellation);
+            eitherValueTask.Result.DoRight(rightAction, argument);
             return default;
         }
 
@@ -522,15 +515,13 @@ public static partial class EitherAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction, CancellationToken cancellation = default)
         {
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -538,12 +529,11 @@ public static partial class EitherAsync
         public async Task DoLeftAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             CancellationToken cancellation = default)
         {
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight}" />
@@ -551,12 +541,11 @@ public static partial class EitherAsync
         public async Task DoRightAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction,
             CancellationToken cancellation = default)
         {
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -569,15 +558,13 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />
@@ -585,12 +572,11 @@ public static partial class EitherAsync
         public async Task DoLeftAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TLeft, TArgument, CancellationToken, Task> asyncLeftAction,
             TArgument argument, CancellationToken cancellation = default)
         {
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight,TArgument}" />
@@ -599,12 +585,11 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             var either = eitherValueTask.IsCompletedSuccessfully
                 ? eitherValueTask.Result
                 : await eitherValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (either.HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/EitherAsync.Extension.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.cs
@@ -217,7 +217,7 @@ public static partial class EitherAsync
             _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
             _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -254,7 +254,7 @@ public static partial class EitherAsync
             _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
             _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
             if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
-            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
+            else await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />

--- a/src/AInq.Optional.Async/EitherAsync.Extension.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Extension.cs
@@ -28,19 +28,26 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
-                                                                                                   .AsEitherAsync<TLeftResult, TRight>(cancellation)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return either.HasLeft
+                ? asyncLeftSelector.Invoke(either.Left, cancellation).AsEitherAsync<TLeftResult, TRight>(cancellation)
                 : new ValueTask<Either<TLeftResult, TRight>>(Either.Right<TLeftResult, TRight>(either.Right));
+        }
 
         /// <inheritdoc cref="Either.SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRight}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeftResult, TRight>> SelectLeftAsync<TLeftResult>(
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRight>>> asyncLeftSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            return either.HasLeft
+                ? asyncLeftSelector.Invoke(either.Left, cancellation)
                 : new ValueTask<Either<TLeftResult, TRight>>(Either.Right<TLeftResult, TRight>(either.Right));
+        }
 
 #endregion
 
@@ -51,19 +58,26 @@ public static partial class EitherAsync
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation)
-                .AsEitherAsync<TLeft, TRightResult>(cancellation)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasRight
+                ? asyncRightSelector.Invoke(either.Right, cancellation).AsEitherAsync<TLeft, TRightResult>(cancellation)
                 : new ValueTask<Either<TLeft, TRightResult>>(Either.Left<TLeft, TRightResult>(either.Left));
+        }
 
         /// <inheritdoc cref="Either.SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,Either{TLeft,TRightResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Either<TLeft, TRightResult>> SelectRightAsync<TRightResult>(
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeft, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasRight
+                ? asyncRightSelector.Invoke(either.Right, cancellation)
                 : new ValueTask<Either<TLeft, TRightResult>>(Either.Left<TLeft, TRightResult>(either.Left));
+        }
 
 #endregion
 
@@ -75,12 +89,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
-                                                                                                   .AsEitherAsync<TLeftResult,
-                                                                                                       TRightResult>(cancellation)
-                : (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation)
-                .AsEitherAsync<TLeftResult, TRightResult>(cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasLeft
+                ? asyncLeftSelector.Invoke(either.Left, cancellation).AsEitherAsync<TLeftResult, TRightResult>(cancellation)
+                : asyncRightSelector.Invoke(either.Right, cancellation).AsEitherAsync<TLeftResult, TRightResult>(cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
@@ -88,10 +104,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TRightResult>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
-                : (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation)
-                .AsEitherAsync<TLeftResult, TRightResult>(cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasLeft
+                ? asyncLeftSelector.Invoke(either.Left, cancellation)
+                : asyncRightSelector.Invoke(either.Right, cancellation).AsEitherAsync<TLeftResult, TRightResult>(cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -99,11 +119,14 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TLeftResult>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
-                                                                                                   .AsEitherAsync<TLeftResult,
-                                                                                                       TRightResult>(cancellation)
-                : (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasLeft
+                ? asyncLeftSelector.Invoke(either.Left, cancellation).AsEitherAsync<TLeftResult, TRightResult>(cancellation)
+                : asyncRightSelector.Invoke(either.Right, cancellation);
+        }
 
         /// <inheritdoc cref="Either.Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,Either{TLeftResult,TRightResult}},Func{TRight,Either{TLeftResult,TRightResult}})" />
         [PublicAPI, Pure]
@@ -111,9 +134,12 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncLeftSelector,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<Either<TLeftResult, TRightResult>>> asyncRightSelector,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector))).Invoke(either.Left, cancellation)
-                : (asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector))).Invoke(either.Right, cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftSelector ?? throw new ArgumentNullException(nameof(asyncLeftSelector));
+            _ = asyncRightSelector ?? throw new ArgumentNullException(nameof(asyncRightSelector));
+            return either.HasLeft ? asyncLeftSelector.Invoke(either.Left, cancellation) : asyncRightSelector.Invoke(either.Right, cancellation);
+        }
 
 #endregion
 
@@ -124,18 +150,22 @@ public static partial class EitherAsync
         public ValueTask<TLeft> LeftOrDefaultAsync(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TLeft>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? new ValueTask<TLeft>(either.Left)
-                : (asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator))).Invoke(cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return either.HasLeft ? new ValueTask<TLeft>(either.Left) : asyncDefaultGenerator.Invoke(cancellation);
+        }
 
         /// <inheritdoc cref="Either.RightOrDefault{TLeft,TRight}(Either{TLeft,TRight},Func{TRight})" />
         [PublicAPI, Pure]
         public ValueTask<TRight> RightOrDefaultAsync(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TRight>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? new ValueTask<TRight>(either.Right)
-                : (asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator))).Invoke(cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return either.HasRight ? new ValueTask<TRight>(either.Right) : asyncDefaultGenerator.Invoke(cancellation);
+        }
 
 #endregion
 
@@ -145,17 +175,21 @@ public static partial class EitherAsync
         [PublicAPI, Pure]
         public ValueTask<TLeft> ToLeftAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TLeft>> asyncRightToLeft,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? new ValueTask<TLeft>(either.Left)
-                : (asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft))).Invoke(either.Right, cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncRightToLeft ?? throw new ArgumentNullException(nameof(asyncRightToLeft));
+            return either.HasLeft ? new ValueTask<TLeft>(either.Left) : asyncRightToLeft.Invoke(either.Right, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToRight{TLeft,TRight}" />
         [PublicAPI, Pure]
         public ValueTask<TRight> ToRightAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TRight>> asyncLeftToRight,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? new ValueTask<TRight>(either.Right)
-                : (asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight))).Invoke(either.Left, cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftToRight ?? throw new ArgumentNullException(nameof(asyncLeftToRight));
+            return either.HasRight ? new ValueTask<TRight>(either.Right) : asyncLeftToRight.Invoke(either.Left, cancellation);
+        }
 
         /// <inheritdoc cref="Either.ToValue{TLeft,TRight,TResult}" />
         [PublicAPI, Pure]
@@ -163,9 +197,12 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, ValueTask<TResult>> asyncFromLeft,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, ValueTask<TResult>> asyncFromRight,
             CancellationToken cancellation = default)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft))).Invoke(either.Left, cancellation)
-                : (asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight))).Invoke(either.Right, cancellation);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncFromLeft ?? throw new ArgumentNullException(nameof(asyncFromLeft));
+            _ = asyncFromRight ?? throw new ArgumentNullException(nameof(asyncFromRight));
+            return either.HasLeft ? asyncFromLeft.Invoke(either.Left, cancellation) : asyncFromRight.Invoke(either.Right, cancellation);
+        }
 
 #endregion
 
@@ -176,12 +213,11 @@ public static partial class EitherAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             [InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction, CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight}" />
@@ -189,9 +225,9 @@ public static partial class EitherAsync
         public async Task DoLeftAsync([InstantHandle(RequireAwait = true)] Func<TLeft, CancellationToken, Task> asyncLeftAction,
             CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight}" />
@@ -199,9 +235,9 @@ public static partial class EitherAsync
         public async Task DoRightAsync([InstantHandle(RequireAwait = true)] Func<TRight, CancellationToken, Task> asyncRightAction,
             CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, cancellation)
-                    .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -214,12 +250,11 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
-            else
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoLeft{TLeft,TRight,TArgument}" />
@@ -227,9 +262,9 @@ public static partial class EitherAsync
         public async Task DoLeftAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TLeft, TArgument, CancellationToken, Task> asyncLeftAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                await (asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction))).Invoke(either.Left, argument, cancellation)
-                                                                                                   .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncLeftAction ?? throw new ArgumentNullException(nameof(asyncLeftAction));
+            if (either.HasLeft) await asyncLeftAction.Invoke(either.Left, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Either.DoRight{TLeft,TRight,TArgument}" />
@@ -238,9 +273,9 @@ public static partial class EitherAsync
             [InstantHandle(RequireAwait = true)] Func<TRight, TArgument, CancellationToken, Task> asyncRightAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasRight)
-                await (asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction))).Invoke(either.Right, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = asyncRightAction ?? throw new ArgumentNullException(nameof(asyncRightAction));
+            if (either.HasRight) await asyncRightAction.Invoke(either.Right, argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/EitherAsync.Linq.Enumerator.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Linq.Enumerator.cs
@@ -34,6 +34,29 @@ public static partial class EitherAsync
                     yield return either.Left;
         }
 
+        /// <inheritdoc cref="Either.LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TLeft,bool})" />
+        [PublicAPI, LinqTunnel]
+        public async IAsyncEnumerable<TLeft> LeftValues(Func<TLeft, bool> filter, [EnumeratorCancellation] CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            await foreach (var either in collection.WithCancellation(cancellation).ConfigureAwait(false))
+                if (either is {HasLeft: true} && filter.Invoke(either.Left))
+                    yield return either.Left;
+        }
+
+        /// <inheritdoc cref="Either.LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TLeft,bool})" />
+        [PublicAPI, LinqTunnel]
+        public async IAsyncEnumerable<TLeft> LeftValues(Func<TLeft, CancellationToken, ValueTask<bool>> filter,
+            [EnumeratorCancellation] CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            await foreach (var either in collection.WithCancellation(cancellation).ConfigureAwait(false))
+                if (either is {HasLeft: true} && await filter.Invoke(either.Left, cancellation).ConfigureAwait(false))
+                    yield return either.Left;
+        }
+
         /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}})" />
         [PublicAPI]
         public async IAsyncEnumerable<TRight> RightValues([EnumeratorCancellation] CancellationToken cancellation = default)
@@ -41,6 +64,30 @@ public static partial class EitherAsync
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await foreach (var either in collection.WithCancellation(cancellation).ConfigureAwait(false))
                 if (either is {HasRight: true})
+                    yield return either.Right;
+        }
+
+        /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TRight,bool})" />
+        [PublicAPI, LinqTunnel]
+        public async IAsyncEnumerable<TRight> RightValues(Func<TRight, bool> filter,
+            [EnumeratorCancellation] CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            await foreach (var either in collection.WithCancellation(cancellation).ConfigureAwait(false))
+                if (either is {HasRight: true} && filter.Invoke(either.Right))
+                    yield return either.Right;
+        }
+
+        /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TRight,bool})" />
+        [PublicAPI, LinqTunnel]
+        public async IAsyncEnumerable<TRight> RightValues(Func<TRight, CancellationToken, ValueTask<bool>> filter,
+            [EnumeratorCancellation] CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            await foreach (var either in collection.WithCancellation(cancellation).ConfigureAwait(false))
+                if (either is {HasRight: true} && await filter.Invoke(either.Right, cancellation).ConfigureAwait(false))
                     yield return either.Right;
         }
     }

--- a/src/AInq.Optional.Async/EitherAsync.Linq.Query.cs
+++ b/src/AInq.Optional.Async/EitherAsync.Linq.Query.cs
@@ -30,12 +30,50 @@ public static partial class EitherAsync
             return collection.Where(either => either is {HasLeft: true}).Select(either => either.Left);
         }
 
+        /// <inheritdoc cref="Either.LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TLeft,bool})" />
+        [PublicAPI, LinqTunnel]
+        public IAsyncEnumerable<TLeft> LeftValues(Func<TLeft, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasLeft: true} && filter.Invoke(either.Left)).Select(either => either.Left);
+        }
+
+        /// <inheritdoc cref="Either.LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TLeft,bool})" />
+        [PublicAPI, LinqTunnel]
+        public IAsyncEnumerable<TLeft> LeftValues(Func<TLeft, CancellationToken, ValueTask<bool>> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(async (either, ctx) => either is {HasLeft: true} && await filter.Invoke(either.Left, ctx).ConfigureAwait(false))
+                             .Select(either => either.Left);
+        }
+
         /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}})" />
         [PublicAPI, LinqTunnel]
         public IAsyncEnumerable<TRight> RightValues()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return collection.Where(either => either is {HasRight: true}).Select(either => either.Right);
+        }
+
+        /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TRight,bool})" />
+        [PublicAPI, LinqTunnel]
+        public IAsyncEnumerable<TRight> RightValues(Func<TRight, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasRight: true} && filter.Invoke(either.Right)).Select(either => either.Right);
+        }
+
+        /// <inheritdoc cref="Either.RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TRight,bool})" />
+        [PublicAPI, LinqTunnel]
+        public IAsyncEnumerable<TRight> RightValues(Func<TRight, CancellationToken, ValueTask<bool>> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(async (either, ctx) => either is {HasRight: true} && await filter.Invoke(either.Right, ctx).ConfigureAwait(false))
+                             .Select(either => either.Right);
         }
     }
 }

--- a/src/AInq.Optional.Async/EitherAsync.cs
+++ b/src/AInq.Optional.Async/EitherAsync.cs
@@ -20,9 +20,12 @@ public static partial class EitherAsync
     /// <inheritdoc cref="Either.Left{TLeft,TRight}(TLeft)" />
     [PublicAPI, Pure]
     public static ValueTask<Either<TLeft, TRight>> LeftAsync<TLeft, TRight>(Task<TLeft> leftTask, CancellationToken cancellation = default)
-        => (leftTask ?? throw new ArgumentNullException(nameof(leftTask))).Status is TaskStatus.RanToCompletion
+    {
+        _ = leftTask ?? throw new ArgumentNullException(nameof(leftTask));
+        return leftTask.Status is TaskStatus.RanToCompletion
             ? new ValueTask<Either<TLeft, TRight>>(Either.Left<TLeft, TRight>(leftTask.Result))
             : AwaitLeft<TLeft, TRight>(leftTask.WaitAsync(cancellation));
+    }
 
     /// <inheritdoc cref="Either.Left{TLeft,TRight}(TLeft)" />
     [PublicAPI, Pure]
@@ -34,9 +37,12 @@ public static partial class EitherAsync
     /// <inheritdoc cref="Either.Right{TLeft,TRight}(TRight)" />
     [PublicAPI, Pure]
     public static ValueTask<Either<TLeft, TRight>> RightAsync<TLeft, TRight>(Task<TRight> rightTask, CancellationToken cancellation = default)
-        => (rightTask ?? throw new ArgumentNullException(nameof(rightTask))).Status is TaskStatus.RanToCompletion
+    {
+        _ = rightTask ?? throw new ArgumentNullException(nameof(rightTask));
+        return rightTask.Status is TaskStatus.RanToCompletion
             ? new ValueTask<Either<TLeft, TRight>>(Either.Right<TLeft, TRight>(rightTask.Result))
             : AwaitRight<TLeft, TRight>(rightTask.WaitAsync(cancellation));
+    }
 
     /// <inheritdoc cref="Either.Right{TLeft,TRight}(TRight)" />
     [PublicAPI, Pure]
@@ -49,7 +55,10 @@ public static partial class EitherAsync
     /// <inheritdoc cref="LeftAsync{TLeft,TRight}(Task{TLeft},CancellationToken)" />
     [PublicAPI, Pure]
     public static ValueTask<Either<TLeft, TRight>> AsEitherAsync<TLeft, TRight>(this Task<TLeft> leftTask, CancellationToken cancellation = default)
-        => LeftAsync<TLeft, TRight>(leftTask ?? throw new ArgumentNullException(nameof(leftTask)), cancellation);
+    {
+        _ = leftTask ?? throw new ArgumentNullException(nameof(leftTask));
+        return LeftAsync<TLeft, TRight>(leftTask, cancellation);
+    }
 
     /// <inheritdoc cref="LeftAsync{TLeft,TRight}(ValueTask{TLeft},CancellationToken)" />
     [PublicAPI, Pure]
@@ -60,7 +69,10 @@ public static partial class EitherAsync
     /// <inheritdoc cref="RightAsync{TLeft,TRight}(Task{TRight},CancellationToken)" />
     [PublicAPI, Pure]
     public static ValueTask<Either<TLeft, TRight>> AsEitherAsync<TLeft, TRight>(this Task<TRight> rightTask, CancellationToken cancellation = default)
-        => RightAsync<TLeft, TRight>(rightTask ?? throw new ArgumentNullException(nameof(rightTask)), cancellation);
+    {
+        _ = rightTask ?? throw new ArgumentNullException(nameof(rightTask));
+        return RightAsync<TLeft, TRight>(rightTask, cancellation);
+    }
 
     /// <inheritdoc cref="RightAsync{TLeft,TRight}(ValueTask{TRight},CancellationToken)" />
     [PublicAPI, Pure]
@@ -72,9 +84,12 @@ public static partial class EitherAsync
     [PublicAPI, Pure]
     public static ValueTask<Either<TRight, TLeft>> Invert<TLeft, TRight>(this Task<Either<TLeft, TRight>> eitherTask,
         CancellationToken cancellation = default)
-        => (eitherTask ?? throw new ArgumentNullException(nameof(eitherTask))).Status is TaskStatus.RanToCompletion
+    {
+        _ = eitherTask ?? throw new ArgumentNullException(nameof(eitherTask));
+        return eitherTask.Status is TaskStatus.RanToCompletion
             ? new ValueTask<Either<TRight, TLeft>>(eitherTask.Result.Invert())
             : AwaitInvert(eitherTask, cancellation);
+    }
 
     /// <inheritdoc cref="Either.Invert{TLeft,TRight}(Either{TLeft,TRight})" />
     [PublicAPI, Pure]

--- a/src/AInq.Optional.Async/MaybeAsync.Extension.Task.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Extension.Task.cs
@@ -25,34 +25,47 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.EitherValue{T,TOther}(Maybe{T},TOther)" />
         [PublicAPI, Pure]
         public ValueTask<Either<T, TOther>> EitherValue<TOther>([NoEnumeration] TOther other, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            return maybeTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Either<T, TOther>>(maybeTask.Result.EitherValue(other))
                 : AwaitEither(maybeTask, other, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.EitherValue{T,TOther}(Maybe{T},Func{TOther})" />
         [PublicAPI, Pure]
         public ValueTask<Either<T, TOther>> EitherValue<TOther>([InstantHandle(RequireAwait = true)] Func<TOther> otherGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Either<T, TOther>>(
-                    maybeTask.Result.EitherValue(otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))))
-                : AwaitEither(maybeTask, otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Either<T, TOther>>(maybeTask.Result.EitherValue(otherGenerator))
+                : AwaitEither(maybeTask, otherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.EitherValue{T,TOther}(Maybe{T},Func{TOther})" />
         [PublicAPI, Pure]
         public ValueTask<Either<T, TOther>> EitherAsync<TOther>(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TOther>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.EitherValueAsync(asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation)
-                : AwaitEither(maybeTask, asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.EitherValueAsync(asyncOtherGenerator, cancellation)
+                : AwaitEither(maybeTask, asyncOtherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.TryValue{T}" />
         [PublicAPI, Pure]
         public ValueTask<Try<T>> TryValue(CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            return maybeTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Try<T>>(maybeTask.Result.TryValue())
                 : AwaitTry(maybeTask, cancellation);
+        }
 
 #endregion
 
@@ -62,17 +75,25 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Maybe<TResult>>(maybeTask.Result.Select(selector) ?? throw new ArgumentNullException(nameof(selector)))
-                : AwaitSelect(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Maybe<TResult>>(maybeTask.Result.Select(selector))
+                : AwaitSelect(maybeTask, selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Select{T,TResult}(Maybe{T},Func{T,Maybe{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Maybe<TResult>>(maybeTask.Result.Select(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelect(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Maybe<TResult>>(maybeTask.Result.Select(selector))
+                : AwaitSelect(maybeTask, selector, cancellation);
+        }
 
 #endregion
 
@@ -83,18 +104,26 @@ public static partial class MaybeAsync
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(maybeTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(maybeTask, asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Select{T,TResult}(Maybe{T},Func{T,Maybe{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(maybeTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(maybeTask, asyncSelector, cancellation);
+        }
 
 #endregion
 
@@ -104,30 +133,38 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<TResult?> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult?>(maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelectOrDefault(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult?>(maybeTask.Result.SelectOrDefault(selector))
+                : AwaitSelectOrDefault(maybeTask, selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult>(
-                    maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)), defaultValue))
-                : AwaitSelectOrDefault(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), defaultValue, cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector, defaultValue))
+                : AwaitSelectOrDefault(maybeTask, selector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitSelectOrDefault(maybeTask,
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector, defaultGenerator))
+                : AwaitSelectOrDefault(maybeTask, selector, defaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -137,30 +174,38 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<TResult?> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult?>(maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelectOrDefault(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult?>(maybeTask.Result.SelectOrDefault(selector))
+                : AwaitSelectOrDefault(maybeTask, selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult>(
-                    maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)), defaultValue))
-                : AwaitSelectOrDefault(maybeTask, selector ?? throw new ArgumentNullException(nameof(selector)), defaultValue, cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector, defaultValue))
+                : AwaitSelectOrDefault(maybeTask, selector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitSelectOrDefault(maybeTask,
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<TResult>(maybeTask.Result.SelectOrDefault(selector, defaultGenerator))
+                : AwaitSelectOrDefault(maybeTask, selector, defaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -171,37 +216,40 @@ public static partial class MaybeAsync
         public ValueTask<TResult?> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelectOrDefault(maybeTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector, [NoEnumeration] TResult defaultValue,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, defaultValue, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, defaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
@@ -209,14 +257,14 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, asyncDefaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -227,37 +275,40 @@ public static partial class MaybeAsync
         public ValueTask<TResult?> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelectOrDefault(maybeTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, defaultValue, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, defaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
@@ -265,14 +316,14 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeTask,
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.SelectOrDefaultAsync(asyncSelector, asyncDefaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeTask, asyncSelector, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -281,34 +332,45 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<T?> ValueOrDefault(CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            return maybeTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<T?>(maybeTask.Result.ValueOrDefault())
                 : AwaitValueOrDefault(maybeTask, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T},T)" />
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefault([NoEnumeration] T defaultValue, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            return maybeTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<T>(maybeTask.Result.ValueOrDefault(defaultValue))
                 : AwaitValueOrDefault(maybeTask, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T},Func{T})" />
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefault([InstantHandle(RequireAwait = true)] Func<T> defaultGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<T>(maybeTask.Result.ValueOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitValueOrDefault(maybeTask, defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<T>(maybeTask.Result.ValueOrDefault(defaultGenerator))
+                : AwaitValueOrDefault(maybeTask, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T},Func{T})" />
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefaultAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<T>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.ValueOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitValueOrDefault(maybeTask,
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.ValueOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitValueOrDefault(maybeTask, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -317,24 +379,36 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Or(Maybe<T> other, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Maybe<T>>(maybeTask.Result.Or(other ?? throw new ArgumentNullException(nameof(other))))
-                : AwaitOr(maybeTask, other ?? throw new ArgumentNullException(nameof(other)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = other ?? throw new ArgumentNullException(nameof(other));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Maybe<T>>(maybeTask.Result.Or(other))
+                : AwaitOr(maybeTask, other, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Func{Maybe{T}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Or([InstantHandle(RequireAwait = true)] Func<Maybe<T>> otherGenerator, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Maybe<T>>(maybeTask.Result.Or(otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))))
-                : AwaitOr(maybeTask, otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Maybe<T>>(maybeTask.Result.Or(otherGenerator))
+                : AwaitOr(maybeTask, otherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> OrAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<Maybe<T>>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.OrAsync(asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation)
-                : AwaitOr(maybeTask, asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.OrAsync(asyncOtherGenerator, cancellation)
+                : AwaitOr(maybeTask, asyncOtherGenerator, cancellation);
+        }
 
 #endregion
 
@@ -343,17 +417,25 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.Filter{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Filter([InstantHandle(RequireAwait = true)] Func<T, bool> filter, CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Maybe<T>>(maybeTask.Result.Filter(filter ?? throw new ArgumentNullException(nameof(filter))))
-                : AwaitFilter(maybeTask, filter ?? throw new ArgumentNullException(nameof(filter)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Maybe<T>>(maybeTask.Result.Filter(filter))
+                : AwaitFilter(maybeTask, filter, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Filter{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> FilterAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> asyncFilter,
             CancellationToken cancellation = default)
-            => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
-                ? maybeTask.Result.FilterAsync(asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter)), cancellation)
-                : AwaitFilter(maybeTask, asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter)), cancellation);
+        {
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter));
+            return maybeTask.Status is TaskStatus.RanToCompletion
+                ? maybeTask.Result.FilterAsync(asyncFilter, cancellation)
+                : AwaitFilter(maybeTask, asyncFilter, cancellation);
+        }
 
 #endregion
 
@@ -364,13 +446,11 @@ public static partial class MaybeAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, [InstantHandle(RequireAwait = true)] Action emptyAction,
             CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(maybeTask,
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                    cancellation);
-            maybeTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)));
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(maybeTask, valueAction, emptyAction, cancellation);
+            maybeTask.Result.Do(valueAction, emptyAction);
             return default;
         }
 
@@ -378,9 +458,10 @@ public static partial class MaybeAsync
         [PublicAPI]
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(maybeTask, valueAction ?? throw new ArgumentNullException(nameof(valueAction)), cancellation);
-            maybeTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)));
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(maybeTask, valueAction, cancellation);
+            maybeTask.Result.Do(valueAction);
             return default;
         }
 
@@ -388,9 +469,10 @@ public static partial class MaybeAsync
         [PublicAPI]
         public ValueTask DoIfEmpty([InstantHandle(RequireAwait = true)] Action emptyAction, CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoIfEmpty(maybeTask, emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)), cancellation);
-            maybeTask.Result.DoIfEmpty(emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)));
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDoIfEmpty(maybeTask, emptyAction, cancellation);
+            maybeTask.Result.DoIfEmpty(emptyAction);
             return default;
         }
 
@@ -403,15 +485,11 @@ public static partial class MaybeAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction,
             [InstantHandle(RequireAwait = true)] Action<TArgument> emptyAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(maybeTask,
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                    argument,
-                    cancellation);
-            maybeTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                argument);
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(maybeTask, valueAction, emptyAction, argument, cancellation);
+            maybeTask.Result.Do(valueAction, emptyAction, argument);
             return default;
         }
 
@@ -420,9 +498,10 @@ public static partial class MaybeAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(maybeTask, valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument, cancellation);
-            maybeTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument);
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(maybeTask, valueAction, argument, cancellation);
+            maybeTask.Result.Do(valueAction, argument);
             return default;
         }
 
@@ -431,9 +510,10 @@ public static partial class MaybeAsync
         public ValueTask DoIfEmpty<TArgument>([InstantHandle(RequireAwait = true)] Action<TArgument> emptyAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoIfEmpty(maybeTask, emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)), argument, cancellation);
-            maybeTask.Result.DoIfEmpty(emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)), argument);
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybeTask.Status is not TaskStatus.RanToCompletion) return AwaitDoIfEmpty(maybeTask, emptyAction, argument, cancellation);
+            maybeTask.Result.DoIfEmpty(emptyAction, argument);
             return default;
         }
 
@@ -446,13 +526,14 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction, CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
-            else await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
+            else await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T}(Maybe{T},Action{T})" />
@@ -460,12 +541,12 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T}" />
@@ -473,11 +554,12 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction,
             CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (!maybe.HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -490,15 +572,15 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
             else
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+                await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T,TArgument}(Maybe{T},Action{T,TArgument},TArgument)" />
@@ -506,12 +588,12 @@ public static partial class MaybeAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T,TArgument}" />
@@ -519,12 +601,12 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            var maybe = (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+            _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            var maybe = maybeTask.Status is TaskStatus.RanToCompletion
                 ? maybeTask.Result
                 : await maybeTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (!maybe.HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/MaybeAsync.Extension.ValueTask.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Extension.ValueTask.cs
@@ -33,22 +33,24 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<Either<T, TOther>> Either<TOther>([InstantHandle(RequireAwait = true)] Func<TOther> otherGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Either<T, TOther>>(
-                    maybeValueTask.Result.EitherValue(otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))))
-                : AwaitEither(maybeValueTask.AsTask(), otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator)), cancellation);
+        {
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Either<T, TOther>>(maybeValueTask.Result.EitherValue(otherGenerator))
+                : AwaitEither(maybeValueTask.AsTask(), otherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.EitherValue{T,TOther}(Maybe{T},Func{TOther})" />
         [PublicAPI, Pure]
         public ValueTask<Either<T, TOther>> EitherAsync<TOther>(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TOther>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.EitherValueAsync(asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)),
-                    cancellation)
-                : AwaitEither(maybeValueTask.AsTask(),
-                    asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)),
-                    cancellation);
+        {
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.EitherValueAsync(asyncOtherGenerator, cancellation)
+                : AwaitEither(maybeValueTask.AsTask(), asyncOtherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.TryValue{T}" />
         [PublicAPI, Pure]
@@ -65,17 +67,23 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Maybe<TResult>>(maybeValueTask.Result.Select(selector) ?? throw new ArgumentNullException(nameof(selector)))
-                : AwaitSelect(maybeValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Maybe<TResult>>(maybeValueTask.Result.Select(selector))
+                : AwaitSelect(maybeValueTask.AsTask(), selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Select{T,TResult}(Maybe{T},Func{T,Maybe{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
                 ? new ValueTask<Maybe<TResult>>(maybeValueTask.Result.Select(selector))
-                : AwaitSelect(maybeValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+                : AwaitSelect(maybeValueTask.AsTask(), selector, cancellation);
+        }
 
 #endregion
 
@@ -86,18 +94,24 @@ public static partial class MaybeAsync
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(maybeValueTask.AsTask(), asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(maybeValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Select{T,TResult}(Maybe{T},Func{T,Maybe{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(maybeValueTask.AsTask(), asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(maybeValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
 #endregion
 
@@ -107,33 +121,35 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<TResult?> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult?>(maybeValueTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult?>(maybeValueTask.Result.SelectOrDefault(selector))
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultValue))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector, defaultValue))
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector, defaultGenerator))
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, defaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -143,33 +159,35 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<TResult?> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
                 ? new ValueTask<TResult?>(maybeValueTask.Result.SelectOrDefault(selector))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultValue))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector, defaultValue))
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefault<TResult>([InstantHandle(RequireAwait = true)] Func<T, Maybe<TResult>> selector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    selector ?? throw new ArgumentNullException(nameof(selector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<TResult>(maybeValueTask.Result.SelectOrDefault(selector, defaultGenerator))
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), selector, defaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -180,39 +198,37 @@ public static partial class MaybeAsync
         public ValueTask<TResult?> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector, [NoEnumeration] TResult defaultValue,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, defaultValue, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, defaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
@@ -220,14 +236,13 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, asyncDefaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -238,39 +253,37 @@ public static partial class MaybeAsync
         public ValueTask<TResult?> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultValue,
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, defaultValue, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, defaultValue, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, defaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
@@ -278,14 +291,13 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitSelectOrDefault(maybeValueTask.AsTask(),
-                    asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.SelectOrDefaultAsync(asyncSelector, asyncDefaultGenerator, cancellation)
+                : AwaitSelectOrDefault(maybeValueTask.AsTask(), asyncSelector, asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -308,23 +320,23 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T},Func{T})" />
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefault([InstantHandle(RequireAwait = true)] Func<T> defaultGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<T>(
-                    maybeValueTask.Result.ValueOrDefault(defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))))
-                : AwaitValueOrDefault(maybeValueTask.AsTask(),
-                    defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator)),
-                    cancellation);
+        {
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<T>(maybeValueTask.Result.ValueOrDefault(defaultGenerator))
+                : AwaitValueOrDefault(maybeValueTask.AsTask(), defaultGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.ValueOrDefault{T}(Maybe{T},Func{T})" />
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefaultAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<T>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.ValueOrDefaultAsync(asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation)
-                : AwaitValueOrDefault(maybeValueTask.AsTask(),
-                    asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator)),
-                    cancellation);
+        {
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.ValueOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : AwaitValueOrDefault(maybeValueTask.AsTask(), asyncDefaultGenerator, cancellation);
+        }
 
 #endregion
 
@@ -333,24 +345,33 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Or(Maybe<T> other, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Or(other ?? throw new ArgumentNullException(nameof(other))))
-                : AwaitOr(maybeValueTask.AsTask(), other ?? throw new ArgumentNullException(nameof(other)), cancellation);
+        {
+            _ = other ?? throw new ArgumentNullException(nameof(other));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Or(other))
+                : AwaitOr(maybeValueTask.AsTask(), other, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Func{Maybe{T}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Or([InstantHandle(RequireAwait = true)] Func<Maybe<T>> otherGenerator, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Or(otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))))
-                : AwaitOr(maybeValueTask.AsTask(), otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator)), cancellation);
+        {
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Or(otherGenerator))
+                : AwaitOr(maybeValueTask.AsTask(), otherGenerator, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> OrAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<Maybe<T>>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.OrAsync(asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation)
-                : AwaitOr(maybeValueTask.AsTask(), asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation);
+        {
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.OrAsync(asyncOtherGenerator, cancellation)
+                : AwaitOr(maybeValueTask.AsTask(), asyncOtherGenerator, cancellation);
+        }
 
 #endregion
 
@@ -359,17 +380,23 @@ public static partial class MaybeAsync
         /// <inheritdoc cref="Maybe.Filter{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> Filter([InstantHandle(RequireAwait = true)] Func<T, bool> filter, CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Filter(filter ?? throw new ArgumentNullException(nameof(filter))))
-                : AwaitFilter(maybeValueTask.AsTask(), filter ?? throw new ArgumentNullException(nameof(filter)), cancellation);
+        {
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Maybe<T>>(maybeValueTask.Result.Filter(filter))
+                : AwaitFilter(maybeValueTask.AsTask(), filter, cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Filter{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> FilterAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> asyncFilter,
             CancellationToken cancellation = default)
-            => maybeValueTask.IsCompletedSuccessfully
-                ? maybeValueTask.Result.FilterAsync(asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter)), cancellation)
-                : AwaitFilter(maybeValueTask.AsTask(), asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter)), cancellation);
+        {
+            _ = asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter));
+            return maybeValueTask.IsCompletedSuccessfully
+                ? maybeValueTask.Result.FilterAsync(asyncFilter, cancellation)
+                : AwaitFilter(maybeValueTask.AsTask(), asyncFilter, cancellation);
+        }
 
 #endregion
 
@@ -380,13 +407,10 @@ public static partial class MaybeAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, [InstantHandle(RequireAwait = true)] Action emptyAction,
             CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDo(maybeValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                    cancellation);
-            maybeValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDo(maybeValueTask.AsTask(), valueAction, emptyAction, cancellation);
+            maybeValueTask.Result.Do(valueAction, emptyAction);
             return default;
         }
 
@@ -394,9 +418,9 @@ public static partial class MaybeAsync
         [PublicAPI]
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDo(maybeValueTask.AsTask(), valueAction ?? throw new ArgumentNullException(nameof(valueAction)), cancellation);
-            maybeValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDo(maybeValueTask.AsTask(), valueAction, cancellation);
+            maybeValueTask.Result.Do(valueAction);
             return default;
         }
 
@@ -404,9 +428,9 @@ public static partial class MaybeAsync
         [PublicAPI]
         public ValueTask DoIfEmpty([InstantHandle(RequireAwait = true)] Action emptyAction, CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDoIfEmpty(maybeValueTask.AsTask(), emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)), cancellation);
-            maybeValueTask.Result.DoIfEmpty(emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDoIfEmpty(maybeValueTask.AsTask(), emptyAction, cancellation);
+            maybeValueTask.Result.DoIfEmpty(emptyAction);
             return default;
         }
 
@@ -419,15 +443,10 @@ public static partial class MaybeAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction,
             [InstantHandle(RequireAwait = true)] Action<TArgument> emptyAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDo(maybeValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                    argument,
-                    cancellation);
-            maybeValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                argument);
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDo(maybeValueTask.AsTask(), valueAction, emptyAction, argument, cancellation);
+            maybeValueTask.Result.Do(valueAction, emptyAction, argument);
             return default;
         }
 
@@ -436,9 +455,9 @@ public static partial class MaybeAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDo(maybeValueTask.AsTask(), valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument, cancellation);
-            maybeValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument);
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDo(maybeValueTask.AsTask(), valueAction, argument, cancellation);
+            maybeValueTask.Result.Do(valueAction, argument);
             return default;
         }
 
@@ -447,12 +466,9 @@ public static partial class MaybeAsync
         public ValueTask DoIfEmpty<TArgument>([InstantHandle(RequireAwait = true)] Action<TArgument> emptyAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if (!maybeValueTask.IsCompletedSuccessfully)
-                return AwaitDoIfEmpty(maybeValueTask.AsTask(),
-                    emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)),
-                    argument,
-                    cancellation);
-            maybeValueTask.Result.DoIfEmpty(emptyAction ?? throw new ArgumentNullException(nameof(emptyAction)), argument);
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybeValueTask.IsCompletedSuccessfully) return AwaitDoIfEmpty(maybeValueTask.AsTask(), emptyAction, argument, cancellation);
+            maybeValueTask.Result.DoIfEmpty(emptyAction, argument);
             return default;
         }
 
@@ -465,13 +481,13 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction, CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
-            else await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
+            else await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T}(Maybe{T},Action{T})" />
@@ -479,12 +495,11 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T}" />
@@ -492,11 +507,11 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction,
             CancellationToken cancellation = default)
         {
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (!maybe.HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -509,15 +524,13 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction, TArgument argument,
             CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
-            else
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
+            else await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T,TArgument}(Maybe{T},Action{T,TArgument},TArgument)" />
@@ -525,12 +538,11 @@ public static partial class MaybeAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (maybe.HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T,TArgument}" />
@@ -538,12 +550,11 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction,
             TArgument argument, CancellationToken cancellation = default)
         {
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
             var maybe = maybeValueTask.IsCompletedSuccessfully
                 ? maybeValueTask.Result
                 : await maybeValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (!maybe.HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/MaybeAsync.Extension.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Extension.cs
@@ -27,9 +27,13 @@ public static partial class MaybeAsync
         public ValueTask<Either<T, TOther>> EitherValueAsync<TOther>(
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TOther>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybe.HasValue
                 ? new ValueTask<Either<T, TOther>>(Optional.Either.Left<T, TOther>(maybe.Value))
-                : AwaitEither<T, TOther>(asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator)), cancellation);
+                : AwaitEither<T, TOther>(asyncOtherGenerator, cancellation);
+        }
 
 #endregion
 
@@ -40,19 +44,24 @@ public static partial class MaybeAsync
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                                                                                           .AsMaybeAsync(cancellation)
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybe.HasValue
+                ? asyncSelector.Invoke(maybe.Value, cancellation).AsMaybeAsync(cancellation)
                 : new ValueTask<Maybe<TResult>>(Maybe.None<TResult>());
+        }
 
         /// <inheritdoc cref="Maybe.Select{T,TResult}(Maybe{T},Func{T,Maybe{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                : new ValueTask<Maybe<TResult>>(Maybe.None<TResult>());
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybe.HasValue ? asyncSelector.Invoke(maybe.Value, cancellation) : new ValueTask<Maybe<TResult>>(Maybe.None<TResult>());
+        }
 
 #endregion
 
@@ -64,9 +73,10 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                return new ValueTask<TResult?>(default(TResult));
-            var selected = (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            if (!maybe.HasValue) return new ValueTask<TResult?>(default(TResult));
+            var selected = asyncSelector.Invoke(maybe.Value, cancellation);
             return selected.IsCompletedSuccessfully ? new ValueTask<TResult?>(selected.Result) : AwaitNullable(selected);
         }
 
@@ -75,18 +85,23 @@ public static partial class MaybeAsync
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector, [NoEnumeration] TResult defaultValue,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                : new ValueTask<TResult>(defaultValue);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybe.HasValue ? asyncSelector.Invoke(maybe.Value, cancellation) : new ValueTask<TResult>(defaultValue);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                : new ValueTask<TResult>((defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke());
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybe.HasValue ? asyncSelector.Invoke(maybe.Value, cancellation) : new ValueTask<TResult>(defaultGenerator.Invoke());
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
@@ -94,9 +109,12 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                : (asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator))).Invoke(cancellation);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybe.HasValue ? asyncSelector.Invoke(maybe.Value, cancellation) : asyncDefaultGenerator.Invoke(cancellation);
+        }
 
 #endregion
 
@@ -107,34 +125,40 @@ public static partial class MaybeAsync
         public ValueTask<TResult?> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                                                                                           .ValueOrDefault(cancellation)
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybe.HasValue
+                ? asyncSelector.Invoke(maybe.Value, cancellation).ValueOrDefault(cancellation)
                 : new ValueTask<TResult?>(default(TResult));
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},TResult)" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [NoEnumeration] TResult defaultValue, CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                                                                                           .ValueOrDefault(defaultValue, cancellation)
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return maybe.HasValue
+                ? asyncSelector.Invoke(maybe.Value, cancellation).ValueOrDefault(defaultValue, cancellation)
                 : new ValueTask<TResult>(defaultValue);
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
         public ValueTask<TResult> SelectOrDefaultAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<TResult> defaultGenerator, CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                                                                                           .ValueOrDefault(
-                                                                                               defaultGenerator
-                                                                                               ?? throw new ArgumentNullException(
-                                                                                                   nameof(defaultGenerator)),
-                                                                                               cancellation)
-                : new ValueTask<TResult>((defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke());
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybe.HasValue
+                ? asyncSelector.Invoke(maybe.Value, cancellation).ValueOrDefault(defaultGenerator, cancellation)
+                : new ValueTask<TResult>(defaultGenerator.Invoke());
+        }
 
         /// <inheritdoc cref="Maybe.SelectOrDefault{T,TResult}(Maybe{T},Func{T,Maybe{TResult}},Func{TResult})" />
         [PublicAPI, Pure]
@@ -142,14 +166,14 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Maybe<TResult>>> asyncSelector,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<TResult>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(maybe.Value, cancellation)
-                                                                                           .ValueOrDefaultAsync(
-                                                                                               asyncDefaultGenerator
-                                                                                               ?? throw new ArgumentNullException(
-                                                                                                   nameof(asyncDefaultGenerator)),
-                                                                                               cancellation)
-                : (asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator))).Invoke(cancellation);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybe.HasValue
+                ? asyncSelector.Invoke(maybe.Value, cancellation).ValueOrDefaultAsync(asyncDefaultGenerator, cancellation)
+                : asyncDefaultGenerator.Invoke(cancellation);
+        }
 
 #endregion
 
@@ -159,25 +183,31 @@ public static partial class MaybeAsync
         [PublicAPI, Pure]
         public ValueTask<T> ValueOrDefaultAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<T>> asyncDefaultGenerator,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? new ValueTask<T>(maybe.Value)
-                : (asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator))).Invoke(cancellation);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncDefaultGenerator ?? throw new ArgumentNullException(nameof(asyncDefaultGenerator));
+            return maybe.HasValue ? new ValueTask<T>(maybe.Value) : asyncDefaultGenerator.Invoke(cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Or{T}(Maybe{T},Maybe{T})" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> OrAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, ValueTask<Maybe<T>>> asyncOtherGenerator,
             CancellationToken cancellation = default)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? new ValueTask<Maybe<T>>(maybe)
-                : (asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator))).Invoke(cancellation);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncOtherGenerator ?? throw new ArgumentNullException(nameof(asyncOtherGenerator));
+            return maybe.HasValue ? new ValueTask<Maybe<T>>(maybe) : asyncOtherGenerator.Invoke(cancellation);
+        }
 
         /// <inheritdoc cref="Maybe.Filter{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> FilterAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> asyncFilter,
             CancellationToken cancellation = default)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue) return new ValueTask<Maybe<T>>(Maybe.None<T>());
-            var result = (asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter))).Invoke(maybe.Value, cancellation);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncFilter ?? throw new ArgumentNullException(nameof(asyncFilter));
+            if (!maybe.HasValue) return new ValueTask<Maybe<T>>(Maybe.None<T>());
+            var result = asyncFilter.Invoke(maybe.Value, cancellation);
             return result.IsCompletedSuccessfully ? new ValueTask<Maybe<T>>(result.Result ? maybe : Maybe.None<T>()) : AwaitFilter(maybe, result);
         }
 
@@ -190,10 +220,11 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction, CancellationToken cancellation = default)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
-            else await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
+            else await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T}(Maybe{T},Action{T})" />
@@ -201,9 +232,9 @@ public static partial class MaybeAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             CancellationToken cancellation = default)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, cancellation)
-                    .ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T}" />
@@ -211,8 +242,9 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync([InstantHandle(RequireAwait = true)] Func<CancellationToken, Task> asyncEmptyAction,
             CancellationToken cancellation = default)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(cancellation).ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(cancellation).ConfigureAwait(false);
         }
 
 #endregion
@@ -225,12 +257,11 @@ public static partial class MaybeAsync
             [InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
-            else
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
+            else await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.Do{T,TArgument}(Maybe{T},Action{T,TArgument},TArgument)" />
@@ -238,9 +269,9 @@ public static partial class MaybeAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(maybe.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            if (maybe.HasValue) await asyncValueAction.Invoke(maybe.Value, argument, cancellation).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="Maybe.DoIfEmpty{T,TArgument}" />
@@ -248,9 +279,9 @@ public static partial class MaybeAsync
         public async Task DoIfEmptyAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<TArgument, CancellationToken, Task> asyncEmptyAction,
             TArgument argument, CancellationToken cancellation = default)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                await (asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction))).Invoke(argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = asyncEmptyAction ?? throw new ArgumentNullException(nameof(asyncEmptyAction));
+            if (!maybe.HasValue) await asyncEmptyAction.Invoke(argument, cancellation).ConfigureAwait(false);
         }
 
 #endregion

--- a/src/AInq.Optional.Async/MaybeAsync.Linq.Alias.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Linq.Alias.cs
@@ -1,0 +1,167 @@
+﻿// Copyright 2021 Anton Andryushchenko
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace AInq.Optional;
+
+public static partial class MaybeAsync
+{
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IAsyncEnumerable<T> collection)
+    {
+        /// <inheritdoc cref="MaybeFirstAsync{T}(IAsyncEnumerable{T},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeFirstAsync instead")]
+        public ValueTask<Maybe<T>> FirstOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirstAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeFirstAsync{T}(IAsyncEnumerable{T},Func{T,bool},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeFirstAsync instead")]
+        public ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeFirstAsync(filter, cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeFirstAsync{T}(IAsyncEnumerable{T},Func{T,CancellationToken,ValueTask{bool}},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeFirstAsync instead")]
+        public ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeFirstAsync(filter, cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeLastAsync{T}(IAsyncEnumerable{T},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeLastAsync instead")]
+        public ValueTask<Maybe<T>> LastOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLastAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeLastAsync{T}(IAsyncEnumerable{T},Func{T,bool},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeLastAsync instead")]
+        public ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeLastAsync(filter, cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeLastAsync{T}(IAsyncEnumerable{T},Func{T,CancellationToken,ValueTask{bool}},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeLastAsync instead")]
+        public ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeLastAsync(filter, cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeSingleAsync{T}(IAsyncEnumerable{T},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeSingleAsync instead")]
+        public ValueTask<Maybe<T>> SingleOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingleAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeSingleAsync{T}(IAsyncEnumerable{T},Func{T,bool},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeSingleAsync instead")]
+        public ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeSingleAsync(filter, cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeSingleAsync{T}(IAsyncEnumerable{T},Func{T,CancellationToken,ValueTask{bool}},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeSingleAsync instead")]
+        public ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+            CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeSingleAsync(filter, cancellation);
+        }
+    }
+
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IAsyncEnumerable<T?> collection)
+        where T : class
+    {
+        /// <inheritdoc cref="MaybeFirstNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeFirstNotNullAsync instead")]
+        public ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirstNotNullAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeLastNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeLastNotNullAsync instead")]
+        public ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLastNotNullAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeSingleNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeSingleNotNullAsync instead")]
+        public ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingleNotNullAsync(cancellation);
+        }
+    }
+
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IAsyncEnumerable<T?> collection)
+        where T : struct
+    {
+        /// <inheritdoc cref="MaybeFirstNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeFirstNotNullAsync instead")]
+        public ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirstNotNullAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeLastNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeLastNotNullAsync instead")]
+        public ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLastNotNullAsync(cancellation);
+        }
+
+        /// <inheritdoc cref="MaybeSingleNotNullAsync{T}(IAsyncEnumerable{T?},CancellationToken)" />
+        [PublicAPI, Obsolete("Use MaybeSingleNotNullAsync instead")]
+        public ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingleNotNullAsync(cancellation);
+        }
+    }
+}

--- a/src/AInq.Optional.Async/MaybeAsync.Linq.Enumerator.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Linq.Enumerator.cs
@@ -98,7 +98,7 @@ public static partial class MaybeAsync
                     return enumerator.Current;
             return Maybe.None<T>();
         }
-        
+
         /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T})" />
         [PublicAPI]
         public async ValueTask<Maybe<T>> MaybeLastAsync(CancellationToken cancellation = default)
@@ -118,7 +118,7 @@ public static partial class MaybeAsync
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             _ = filter ?? throw new ArgumentNullException(nameof(filter));
             var result = Maybe.None<T>();
-            await foreach(var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
+            await foreach (var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
                 if (filter.Invoke(value))
                     result = value;
             return result;
@@ -132,7 +132,7 @@ public static partial class MaybeAsync
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             _ = filter ?? throw new ArgumentNullException(nameof(filter));
             var result = Maybe.None<T>();
-            await foreach(var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
+            await foreach (var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
                 if (await filter.Invoke(value, cancellation).ConfigureAwait(false))
                     result = value;
             return result;
@@ -208,14 +208,14 @@ public static partial class MaybeAsync
                     return enumerator.Current;
             return Maybe.None<T>();
         }
-        
+
         /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
         public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             var result = Maybe.None<T>();
-            await foreach(var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
+            await foreach (var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
                 if (value is not null)
                     result = value;
             return result;
@@ -256,14 +256,14 @@ public static partial class MaybeAsync
                     return enumerator.Current.Value;
             return Maybe.None<T>();
         }
-        
+
         /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
         public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             var result = Maybe.None<T>();
-            await foreach(var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
+            await foreach (var value in collection.WithCancellation(cancellation).ConfigureAwait(false))
                 if (value.HasValue)
                     result = value;
             return result;

--- a/src/AInq.Optional.Async/MaybeAsync.Linq.Enumerator.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Linq.Enumerator.cs
@@ -62,18 +62,18 @@ public static partial class MaybeAsync
     /// <typeparam name="T"> Value type </typeparam>
     extension<T>(IAsyncEnumerable<T> collection)
     {
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);
             return await enumerator.MoveNextAsync().ConfigureAwait(false) ? enumerator.Current : Maybe.None<T>();
         }
 
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeFirstAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -85,9 +85,9 @@ public static partial class MaybeAsync
             return Maybe.None<T>();
         }
 
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeFirstAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -99,9 +99,9 @@ public static partial class MaybeAsync
             return Maybe.None<T>();
         }
         
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             var result = Maybe.None<T>();
@@ -110,9 +110,9 @@ public static partial class MaybeAsync
             return result;
         }
 
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeLastAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -124,9 +124,9 @@ public static partial class MaybeAsync
             return result;
         }
 
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeLastAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -138,9 +138,9 @@ public static partial class MaybeAsync
             return result;
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);
@@ -151,9 +151,9 @@ public static partial class MaybeAsync
                 : result;
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeSingleAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -171,9 +171,9 @@ public static partial class MaybeAsync
             return Maybe.None<T>();
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeSingleAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -197,9 +197,9 @@ public static partial class MaybeAsync
     extension<T>(IAsyncEnumerable<T?> collection)
         where T : class
     {
-        /// <inheritdoc cref="Maybe.FirstNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeFirstNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);
@@ -209,9 +209,9 @@ public static partial class MaybeAsync
             return Maybe.None<T>();
         }
         
-        /// <inheritdoc cref="Maybe.LastNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             var result = Maybe.None<T>();
@@ -221,9 +221,9 @@ public static partial class MaybeAsync
             return result;
         }
 
-        /// <inheritdoc cref="Maybe.SingleNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeSingleNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);
@@ -245,9 +245,9 @@ public static partial class MaybeAsync
     extension<T>(IAsyncEnumerable<T?> collection)
         where T : struct
     {
-        /// <inheritdoc cref="Maybe.FirstNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeFirstNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);
@@ -257,9 +257,9 @@ public static partial class MaybeAsync
             return Maybe.None<T>();
         }
         
-        /// <inheritdoc cref="Maybe.LastNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             var result = Maybe.None<T>();
@@ -269,9 +269,9 @@ public static partial class MaybeAsync
             return result;
         }
 
-        /// <inheritdoc cref="Maybe.SingleNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeSingleNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             await using var enumerator = collection.GetAsyncEnumerator(cancellation);

--- a/src/AInq.Optional.Async/MaybeAsync.Linq.Query.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.Linq.Query.cs
@@ -53,17 +53,17 @@ public static partial class MaybeAsync
     /// <typeparam name="T"> Value type </typeparam>
     extension<T>(IAsyncEnumerable<T> collection)
     {
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe<T>.FromValue).FirstOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeFirstAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -71,9 +71,9 @@ public static partial class MaybeAsync
             return await collection.Where(filter).Select(Maybe<T>.FromValue).FirstOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.FirstOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeFirst{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeFirstAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -81,17 +81,17 @@ public static partial class MaybeAsync
             return await collection.Where(filter).Select(Maybe<T>.FromValue).FirstOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe<T>.FromValue).LastOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeLastAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -99,9 +99,9 @@ public static partial class MaybeAsync
             return await collection.Where(filter).Select(Maybe<T>.FromValue).LastOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.LastOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeLast{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeLastAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -109,17 +109,17 @@ public static partial class MaybeAsync
             return await collection.Where(filter).Select(Maybe<T>.FromValue).LastOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe<T>.FromValue).SingleOrDefaultAsync(Maybe.None<T>(), cancellation).ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
+        public async ValueTask<Maybe<T>> MaybeSingleAsync([InstantHandle(RequireAwait = true)] Func<T, bool> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -130,9 +130,9 @@ public static partial class MaybeAsync
                                    .ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.SingleOrNone{T}(IEnumerable{T},Func{T,bool})" />
+        /// <inheritdoc cref="Maybe.MaybeSingle{T}(IEnumerable{T},Func{T,bool})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleOrNoneAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
+        public async ValueTask<Maybe<T>> MaybeSingleAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<bool>> filter,
             CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
@@ -149,9 +149,9 @@ public static partial class MaybeAsync
     extension<T>(IAsyncEnumerable<T?> collection)
         where T : class
     {
-        /// <inheritdoc cref="Maybe.FirstNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeFirstNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)
@@ -159,9 +159,9 @@ public static partial class MaybeAsync
                                    .ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.LastNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)
@@ -169,9 +169,9 @@ public static partial class MaybeAsync
                                    .ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.SingleNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeSingleNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)
@@ -185,9 +185,9 @@ public static partial class MaybeAsync
     extension<T>(IAsyncEnumerable<T?> collection)
         where T : struct
     {
-        /// <inheritdoc cref="Maybe.FirstNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeFirstNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> FirstNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeFirstNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)
@@ -195,9 +195,9 @@ public static partial class MaybeAsync
                                    .ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.LastNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> LastNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeLastNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)
@@ -205,9 +205,9 @@ public static partial class MaybeAsync
                                    .ConfigureAwait(false);
         }
 
-        /// <inheritdoc cref="Maybe.SingleNotNullOrNone{T}(IEnumerable{T?})" />
+        /// <inheritdoc cref="Maybe.MaybeSingleNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public async ValueTask<Maybe<T>> SingleNotNullOrNoneAsync(CancellationToken cancellation = default)
+        public async ValueTask<Maybe<T>> MaybeSingleNotNullAsync(CancellationToken cancellation = default)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             return await collection.Select(Maybe.ValueIfNotNull)

--- a/src/AInq.Optional.Async/MaybeAsync.cs
+++ b/src/AInq.Optional.Async/MaybeAsync.cs
@@ -20,9 +20,12 @@ public static partial class MaybeAsync
     /// <inheritdoc cref="Maybe.Value{T}(T)" />
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> ValueAsync<T>(Task<T> task, CancellationToken cancellation = default)
-        => (task ?? throw new ArgumentNullException(nameof(task))).Status is TaskStatus.RanToCompletion
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return task.Status is TaskStatus.RanToCompletion
             ? new ValueTask<Maybe<T>>(Maybe.Value(task.Result))
             : AwaitValue(task.WaitAsync(cancellation));
+    }
 
     /// <inheritdoc cref="Maybe.Value{T}(T)" />
     [PublicAPI, Pure]
@@ -35,9 +38,12 @@ public static partial class MaybeAsync
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> ValueIfNotNullAsync<T>(Task<T?> task, CancellationToken cancellation = default)
         where T : class
-        => (task ?? throw new ArgumentNullException(nameof(task))).Status is TaskStatus.RanToCompletion
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return task.Status is TaskStatus.RanToCompletion
             ? task.Result is not null ? new ValueTask<Maybe<T>>(Maybe.Value(task.Result)) : new ValueTask<Maybe<T>>(Maybe.None<T>())
             : AwaitValueIfNotNull(task.WaitAsync(cancellation));
+    }
 
     /// <inheritdoc cref="Maybe.ValueIfNotNull{T}(T)" />
     [PublicAPI, Pure]
@@ -51,9 +57,12 @@ public static partial class MaybeAsync
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> ValueIfNotNullAsync<T>(Task<T?> task, CancellationToken cancellation = default)
         where T : struct
-        => (task ?? throw new ArgumentNullException(nameof(task))).Status is TaskStatus.RanToCompletion
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return task.Status is TaskStatus.RanToCompletion
             ? task.Result.HasValue ? new ValueTask<Maybe<T>>(Maybe.Value(task.Result.Value)) : new ValueTask<Maybe<T>>(Maybe.None<T>())
             : AwaitValueIfNotNull(task.WaitAsync(cancellation));
+    }
 
     /// <inheritdoc cref="Maybe.ValueIfNotNull{T}(T)" />
     [PublicAPI, Pure]
@@ -66,7 +75,10 @@ public static partial class MaybeAsync
     /// <inheritdoc cref="ValueAsync{T}(Task{T},CancellationToken)" />
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> AsMaybeAsync<T>(this Task<T> task, CancellationToken cancellation = default)
-        => ValueAsync(task ?? throw new ArgumentNullException(nameof(task)), cancellation);
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return ValueAsync(task, cancellation);
+    }
 
     /// <inheritdoc cref="ValueAsync{T}(ValueTask{T},CancellationToken)" />
     [PublicAPI, Pure]
@@ -77,7 +89,10 @@ public static partial class MaybeAsync
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> AsMaybeIfNotNullAsync<T>(this Task<T?> task, CancellationToken cancellation = default)
         where T : class
-        => ValueIfNotNullAsync(task ?? throw new ArgumentNullException(nameof(task)), cancellation);
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return ValueIfNotNullAsync(task, cancellation);
+    }
 
     /// <inheritdoc cref="ValueIfNotNullAsync{T}(ValueTask{T?},CancellationToken)" />
     [PublicAPI, Pure]
@@ -89,7 +104,10 @@ public static partial class MaybeAsync
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> AsMaybeIfNotNullAsync<T>(this Task<T?> task, CancellationToken cancellation = default)
         where T : struct
-        => ValueIfNotNullAsync(task ?? throw new ArgumentNullException(nameof(task)), cancellation);
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return ValueIfNotNullAsync(task, cancellation);
+    }
 
     /// <inheritdoc cref="ValueIfNotNullAsync{T}(ValueTask{T?},CancellationToken)" />
     [PublicAPI, Pure]
@@ -100,9 +118,12 @@ public static partial class MaybeAsync
     /// <inheritdoc cref="Maybe.Unwrap{T}(Maybe{Maybe{T}})" />
     [PublicAPI, Pure]
     public static ValueTask<Maybe<T>> Unwrap<T>(this Task<Maybe<Maybe<T>>> maybeTask, CancellationToken cancellation = default)
-        => (maybeTask ?? throw new ArgumentNullException(nameof(maybeTask))).Status is TaskStatus.RanToCompletion
+    {
+        _ = maybeTask ?? throw new ArgumentNullException(nameof(maybeTask));
+        return maybeTask.Status is TaskStatus.RanToCompletion
             ? new ValueTask<Maybe<T>>(maybeTask.Result.Unwrap())
             : AwaitUnwrap(maybeTask, cancellation);
+    }
 
     /// <inheritdoc cref="Maybe.Unwrap{T}(Maybe{Maybe{T}})" />
     [PublicAPI, Pure]

--- a/src/AInq.Optional.Async/TryAsync.Extension.Task.cs
+++ b/src/AInq.Optional.Async/TryAsync.Extension.Task.cs
@@ -25,9 +25,12 @@ public static partial class TryAsync
         /// <inheritdoc cref="Try.MaybeValue{T}" />
         [PublicAPI, Pure]
         public ValueTask<Maybe<T>> MaybeValue(bool suppressException = false, CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            return tryTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Maybe<T>>(tryTask.Result.MaybeValue(suppressException))
                 : AwaitMaybe(tryTask, suppressException, cancellation);
+        }
 
 #endregion
 
@@ -37,17 +40,25 @@ public static partial class TryAsync
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Try<TResult>>(tryTask.Result.Select(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelect(tryTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return tryTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Try<TResult>>(tryTask.Result.Select(selector))
+                : AwaitSelect(tryTask, selector, cancellation);
+        }
 
         /// <inheritdoc cref="Try.Select{T,TResult}(Try{T},Func{T,Try{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, Try<TResult>> selector,
             CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Try<TResult>>(tryTask.Result.Select(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelect(tryTask, selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return tryTask.Status is TaskStatus.RanToCompletion
+                ? new ValueTask<Try<TResult>>(tryTask.Result.Select(selector))
+                : AwaitSelect(tryTask, selector, cancellation);
+        }
 
 #endregion
 
@@ -58,18 +69,26 @@ public static partial class TryAsync
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(tryTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return tryTask.Status is TaskStatus.RanToCompletion
+                ? tryTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(tryTask, asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Try.Select{T,TResult}(Try{T},Func{T,Try{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Try<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(tryTask, asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return tryTask.Status is TaskStatus.RanToCompletion
+                ? tryTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(tryTask, asyncSelector, cancellation);
+        }
 
 #endregion
 
@@ -78,24 +97,31 @@ public static partial class TryAsync
         /// <inheritdoc cref="Try{T}.Throw()" />
         [PublicAPI, AssertionMethod]
         public ValueTask<Try<T>> Throw(CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? new ValueTask<Try<T>>(tryTask.Result.Throw())
-                : AwaitThrow(tryTask, cancellation);
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            return tryTask.Status is TaskStatus.RanToCompletion ? new ValueTask<Try<T>>(tryTask.Result.Throw()) : AwaitThrow(tryTask, cancellation);
+        }
 
         /// <inheritdoc cref="Try{T}.Throw{TException}()" />
         [PublicAPI, AssertionMethod]
         public ValueTask<Try<T>> Throw<TException>(CancellationToken cancellation = default)
             where TException : Exception
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            return tryTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Try<T>>(tryTask.Result.Throw<TException>())
                 : AwaitThrow<T, TException>(tryTask, cancellation);
+        }
 
         /// <inheritdoc cref="Try{T}.Throw(Type)" />
         [PublicAPI, AssertionMethod]
         public ValueTask<Try<T>> Throw(Type exceptionType, CancellationToken cancellation = default)
-            => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
+        {
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            return tryTask.Status is TaskStatus.RanToCompletion
                 ? new ValueTask<Try<T>>(tryTask.Result.Throw(exceptionType))
                 : AwaitThrow(tryTask, exceptionType, cancellation);
+        }
 
 #endregion
 
@@ -106,13 +132,11 @@ public static partial class TryAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction,
             [InstantHandle(RequireAwait = true)] Action<Exception> errorAction, CancellationToken cancellation = default)
         {
-            if ((tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(tryTask,
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                    cancellation);
-            tryTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                errorAction ?? throw new ArgumentNullException(nameof(errorAction)));
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (tryTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(tryTask, valueAction, errorAction, cancellation);
+            tryTask.Result.Do(valueAction, errorAction);
             return default;
         }
 
@@ -121,9 +145,10 @@ public static partial class TryAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, bool throwIfError = false,
             CancellationToken cancellation = default)
         {
-            if ((tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(tryTask, valueAction ?? throw new ArgumentNullException(nameof(valueAction)), throwIfError, cancellation);
-            tryTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), throwIfError);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (tryTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(tryTask, valueAction, throwIfError, cancellation);
+            tryTask.Result.Do(valueAction, throwIfError);
             return default;
         }
 
@@ -131,9 +156,10 @@ public static partial class TryAsync
         [PublicAPI]
         public ValueTask DoIfError([InstantHandle(RequireAwait = true)] Action<Exception> errorAction, CancellationToken cancellation = default)
         {
-            if ((tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDoIfError(tryTask, errorAction ?? throw new ArgumentNullException(nameof(errorAction)), cancellation);
-            tryTask.Result.DoIfError(errorAction ?? throw new ArgumentNullException(nameof(errorAction)));
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (tryTask.Status is not TaskStatus.RanToCompletion) return AwaitDoIfError(tryTask, errorAction, cancellation);
+            tryTask.Result.DoIfError(errorAction);
             return default;
         }
 
@@ -146,15 +172,11 @@ public static partial class TryAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction,
             [InstantHandle(RequireAwait = true)] Action<Exception> errorAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if ((tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(tryTask,
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                    argument,
-                    cancellation);
-            tryTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                argument);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (tryTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(tryTask, valueAction, errorAction, argument, cancellation);
+            tryTask.Result.Do(valueAction, errorAction, argument);
             return default;
         }
 
@@ -163,9 +185,10 @@ public static partial class TryAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction, TArgument argument,
             bool throwIfError = false, CancellationToken cancellation = default)
         {
-            if ((tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is not TaskStatus.RanToCompletion)
-                return AwaitDo(tryTask, valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument, throwIfError, cancellation);
-            tryTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument, throwIfError);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (tryTask.Status is not TaskStatus.RanToCompletion) return AwaitDo(tryTask, valueAction, argument, throwIfError, cancellation);
+            tryTask.Result.Do(valueAction, argument, throwIfError);
             return default;
         }
 
@@ -178,12 +201,11 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, CancellationToken cancellation = default)
         {
-            var @try = (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result
-                : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            var @try = tryTask.Status is TaskStatus.RanToCompletion ? tryTask.Result : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -191,8 +213,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -201,12 +222,10 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction, bool throwIfError = false,
             CancellationToken cancellation = default)
         {
-            var @try = (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result
-                : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            var @try = tryTask.Status is TaskStatus.RanToCompletion ? tryTask.Result : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 
@@ -215,9 +234,9 @@ public static partial class TryAsync
         public async Task DoIfErrorAsync([InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction,
             CancellationToken cancellation = default)
         {
-            var @try = (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result
-                : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            var @try = tryTask.Status is TaskStatus.RanToCompletion ? tryTask.Result : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
             if (@try.Success) return;
             try
             {
@@ -225,8 +244,7 @@ public static partial class TryAsync
             }
             catch (Exception exception)
             {
-                await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                    .ConfigureAwait(false);
+                await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
             }
         }
 
@@ -240,12 +258,11 @@ public static partial class TryAsync
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            var @try = (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result
-                : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            var @try = tryTask.Status is TaskStatus.RanToCompletion ? tryTask.Result : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -253,8 +270,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -263,12 +279,10 @@ public static partial class TryAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, bool throwIfError = false, CancellationToken cancellation = default)
         {
-            var @try = (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-                ? tryTask.Result
-                : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            var @try = tryTask.Status is TaskStatus.RanToCompletion ? tryTask.Result : await tryTask.WaitAsync(cancellation).ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 

--- a/src/AInq.Optional.Async/TryAsync.Extension.ValueTask.cs
+++ b/src/AInq.Optional.Async/TryAsync.Extension.ValueTask.cs
@@ -37,17 +37,23 @@ public static partial class TryAsync
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, TResult> selector,
             CancellationToken cancellation = default)
-            => tryValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Try<TResult>>(tryValueTask.Result.Select(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelect(tryValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return tryValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Try<TResult>>(tryValueTask.Result.Select(selector))
+                : AwaitSelect(tryValueTask.AsTask(), selector, cancellation);
+        }
 
         /// <inheritdoc cref="Try.Select{T,TResult}(Try{T},Func{T,Try{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> Select<TResult>([InstantHandle(RequireAwait = true)] Func<T, Try<TResult>> selector,
             CancellationToken cancellation = default)
-            => tryValueTask.IsCompletedSuccessfully
-                ? new ValueTask<Try<TResult>>(tryValueTask.Result.Select(selector ?? throw new ArgumentNullException(nameof(selector))))
-                : AwaitSelect(tryValueTask.AsTask(), selector ?? throw new ArgumentNullException(nameof(selector)), cancellation);
+        {
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return tryValueTask.IsCompletedSuccessfully
+                ? new ValueTask<Try<TResult>>(tryValueTask.Result.Select(selector))
+                : AwaitSelect(tryValueTask.AsTask(), selector, cancellation);
+        }
 
 #endregion
 
@@ -58,18 +64,24 @@ public static partial class TryAsync
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => tryValueTask.IsCompletedSuccessfully
-                ? tryValueTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(tryValueTask.AsTask(), asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return tryValueTask.IsCompletedSuccessfully
+                ? tryValueTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(tryValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
         /// <inheritdoc cref="Try.Select{T,TResult}(Try{T},Func{T,Try{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Try<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => tryValueTask.IsCompletedSuccessfully
-                ? tryValueTask.Result.SelectAsync(asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation)
-                : AwaitSelect(tryValueTask.AsTask(), asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector)), cancellation);
+        {
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return tryValueTask.IsCompletedSuccessfully
+                ? tryValueTask.Result.SelectAsync(asyncSelector, cancellation)
+                : AwaitSelect(tryValueTask.AsTask(), asyncSelector, cancellation);
+        }
 
 #endregion
 
@@ -106,13 +118,10 @@ public static partial class TryAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction,
             [InstantHandle(RequireAwait = true)] Action<Exception> errorAction, CancellationToken cancellation = default)
         {
-            if (!tryValueTask.IsCompletedSuccessfully)
-                return AwaitDo(tryValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                    cancellation);
-            tryValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                errorAction ?? throw new ArgumentNullException(nameof(errorAction)));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (!tryValueTask.IsCompletedSuccessfully) return AwaitDo(tryValueTask.AsTask(), valueAction, errorAction, cancellation);
+            tryValueTask.Result.Do(valueAction, errorAction);
             return default;
         }
 
@@ -121,12 +130,9 @@ public static partial class TryAsync
         public ValueTask Do([InstantHandle(RequireAwait = true)] Action<T> valueAction, bool throwIfError = false,
             CancellationToken cancellation = default)
         {
-            if (!tryValueTask.IsCompletedSuccessfully)
-                return AwaitDo(tryValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    throwIfError,
-                    cancellation);
-            tryValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), throwIfError);
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (!tryValueTask.IsCompletedSuccessfully) return AwaitDo(tryValueTask.AsTask(), valueAction, throwIfError, cancellation);
+            tryValueTask.Result.Do(valueAction, throwIfError);
             return default;
         }
 
@@ -134,9 +140,9 @@ public static partial class TryAsync
         [PublicAPI]
         public ValueTask DoIfError([InstantHandle(RequireAwait = true)] Action<Exception> errorAction, CancellationToken cancellation = default)
         {
-            if (!tryValueTask.IsCompletedSuccessfully)
-                return AwaitDoIfError(tryValueTask.AsTask(), errorAction ?? throw new ArgumentNullException(nameof(errorAction)), cancellation);
-            tryValueTask.Result.DoIfError(errorAction ?? throw new ArgumentNullException(nameof(errorAction)));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (!tryValueTask.IsCompletedSuccessfully) return AwaitDoIfError(tryValueTask.AsTask(), errorAction, cancellation);
+            tryValueTask.Result.DoIfError(errorAction);
             return default;
         }
 
@@ -149,15 +155,10 @@ public static partial class TryAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction,
             [InstantHandle(RequireAwait = true)] Action<Exception> errorAction, TArgument argument, CancellationToken cancellation = default)
         {
-            if (!tryValueTask.IsCompletedSuccessfully)
-                return AwaitDo(tryValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                    argument,
-                    cancellation);
-            tryValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                errorAction ?? throw new ArgumentNullException(nameof(errorAction)),
-                argument);
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (!tryValueTask.IsCompletedSuccessfully) return AwaitDo(tryValueTask.AsTask(), valueAction, errorAction, argument, cancellation);
+            tryValueTask.Result.Do(valueAction, errorAction, argument);
             return default;
         }
 
@@ -166,13 +167,9 @@ public static partial class TryAsync
         public ValueTask Do<TArgument>([InstantHandle(RequireAwait = true)] Action<T, TArgument> valueAction, TArgument argument,
             bool throwIfError = false, CancellationToken cancellation = default)
         {
-            if (!tryValueTask.IsCompletedSuccessfully)
-                return AwaitDo(tryValueTask.AsTask(),
-                    valueAction ?? throw new ArgumentNullException(nameof(valueAction)),
-                    argument,
-                    throwIfError,
-                    cancellation);
-            tryValueTask.Result.Do(valueAction ?? throw new ArgumentNullException(nameof(valueAction)), argument, throwIfError);
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (!tryValueTask.IsCompletedSuccessfully) return AwaitDo(tryValueTask.AsTask(), valueAction, argument, throwIfError, cancellation);
+            tryValueTask.Result.Do(valueAction, argument, throwIfError);
             return default;
         }
 
@@ -185,12 +182,12 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
             var @try = tryValueTask.IsCompletedSuccessfully
                 ? tryValueTask.Result
                 : await tryValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -198,8 +195,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -208,12 +204,11 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction, bool throwIfError = false,
             CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
             var @try = tryValueTask.IsCompletedSuccessfully
                 ? tryValueTask.Result
                 : await tryValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 
@@ -222,6 +217,7 @@ public static partial class TryAsync
         public async Task DoIfErrorAsync([InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction,
             CancellationToken cancellation = default)
         {
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
             var @try = tryValueTask.IsCompletedSuccessfully
                 ? tryValueTask.Result
                 : await tryValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
@@ -232,8 +228,7 @@ public static partial class TryAsync
             }
             catch (Exception exception)
             {
-                await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                    .ConfigureAwait(false);
+                await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
             }
         }
 
@@ -247,12 +242,12 @@ public static partial class TryAsync
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, TArgument argument,
             CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
             var @try = tryValueTask.IsCompletedSuccessfully
                 ? tryValueTask.Result
                 : await tryValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -260,8 +255,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -270,12 +264,11 @@ public static partial class TryAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, bool throwIfError = false, CancellationToken cancellation = default)
         {
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
             var @try = tryValueTask.IsCompletedSuccessfully
                 ? tryValueTask.Result
                 : await tryValueTask.AsTask().WaitAsync(cancellation).ConfigureAwait(false);
-            if (@try.Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 

--- a/src/AInq.Optional.Async/TryAsync.Extension.cs
+++ b/src/AInq.Optional.Async/TryAsync.Extension.cs
@@ -27,18 +27,24 @@ public static partial class TryAsync
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<TResult>> asyncSelector,
             CancellationToken cancellation = default)
-            => (@try ?? throw new ArgumentNullException(nameof(@try))).Success
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(@try.Value, cancellation).AsTryAsync(cancellation)
+        {
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return @try.Success
+                ? asyncSelector.Invoke(@try.Value, cancellation).AsTryAsync(cancellation)
                 : new ValueTask<Try<TResult>>(Try<TResult>.ConvertError(@try));
+        }
 
         /// <inheritdoc cref="Try.Select{T,TResult}(Try{T},Func{T,Try{TResult}})" />
         [PublicAPI, Pure]
         public ValueTask<Try<TResult>> SelectAsync<TResult>(
             [InstantHandle(RequireAwait = true)] Func<T, CancellationToken, ValueTask<Try<TResult>>> asyncSelector,
             CancellationToken cancellation = default)
-            => (@try ?? throw new ArgumentNullException(nameof(@try))).Success
-                ? (asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector))).Invoke(@try.Value, cancellation)
-                : new ValueTask<Try<TResult>>(Try<TResult>.ConvertError(@try));
+        {
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncSelector ?? throw new ArgumentNullException(nameof(asyncSelector));
+            return @try.Success ? asyncSelector.Invoke(@try.Value, cancellation) : new ValueTask<Try<TResult>>(Try<TResult>.ConvertError(@try));
+        }
 
 #endregion
 
@@ -49,9 +55,10 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction,
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, CancellationToken cancellation = default)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -59,8 +66,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -69,9 +75,9 @@ public static partial class TryAsync
         public async Task DoAsync([InstantHandle(RequireAwait = true)] Func<T, CancellationToken, Task> asyncValueAction, bool throwIfError = false,
             CancellationToken cancellation = default)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, cancellation)
-                    .ConfigureAwait(false);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 
@@ -80,15 +86,16 @@ public static partial class TryAsync
         public async Task DoIfErrorAsync([InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction,
             CancellationToken cancellation = default)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success) return;
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            if (@try.Success) return;
             try
             {
                 @try.Throw();
             }
             catch (Exception exception)
             {
-                await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                    .ConfigureAwait(false);
+                await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
             }
         }
 
@@ -102,9 +109,10 @@ public static partial class TryAsync
             [InstantHandle(RequireAwait = true)] Func<Exception, CancellationToken, Task> asyncErrorAction, TArgument argument,
             CancellationToken cancellation = default)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            _ = asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction));
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else
                 try
                 {
@@ -112,8 +120,7 @@ public static partial class TryAsync
                 }
                 catch (Exception exception)
                 {
-                    await (asyncErrorAction ?? throw new ArgumentNullException(nameof(asyncErrorAction))).Invoke(exception, cancellation)
-                        .ConfigureAwait(false);
+                    await asyncErrorAction.Invoke(exception, cancellation).ConfigureAwait(false);
                 }
         }
 
@@ -122,9 +129,9 @@ public static partial class TryAsync
         public async Task DoAsync<TArgument>([InstantHandle(RequireAwait = true)] Func<T, TArgument, CancellationToken, Task> asyncValueAction,
             TArgument argument, bool throwIfError = false, CancellationToken cancellation = default)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                await (asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction))).Invoke(@try.Value, argument, cancellation)
-                    .ConfigureAwait(false);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = asyncValueAction ?? throw new ArgumentNullException(nameof(asyncValueAction));
+            if (@try.Success) await asyncValueAction.Invoke(@try.Value, argument, cancellation).ConfigureAwait(false);
             else if (throwIfError) @try.Throw();
         }
 

--- a/src/AInq.Optional.Async/TryAsync.cs
+++ b/src/AInq.Optional.Async/TryAsync.cs
@@ -40,7 +40,10 @@ public static partial class TryAsync
     /// <inheritdoc cref="ResultAsync{T}(Task{T},CancellationToken)" />
     [PublicAPI, Pure]
     public static ValueTask<Try<T>> AsTryAsync<T>(this Task<T> task, CancellationToken cancellation = default)
-        => ResultAsync(task ?? throw new ArgumentNullException(nameof(task)), cancellation);
+    {
+        _ = task ?? throw new ArgumentNullException(nameof(task));
+        return ResultAsync(task, cancellation);
+    }
 
     /// <inheritdoc cref="ResultAsync{T}(ValueTask{T},CancellationToken)" />
     [PublicAPI, Pure]
@@ -50,9 +53,10 @@ public static partial class TryAsync
     /// <inheritdoc cref="Try.Unwrap{T}(Try{Try{T}})" />
     [PublicAPI, Pure]
     public static ValueTask<Try<T>> Unwrap<T>(this Task<Try<Try<T>>> tryTask, CancellationToken cancellation = default)
-        => (tryTask ?? throw new ArgumentNullException(nameof(tryTask))).Status is TaskStatus.RanToCompletion
-            ? new ValueTask<Try<T>>(tryTask.Result.Unwrap())
-            : AwaitUnwrap(tryTask, cancellation);
+    {
+        _ = tryTask ?? throw new ArgumentNullException(nameof(tryTask));
+        return tryTask.Status is TaskStatus.RanToCompletion ? new ValueTask<Try<T>>(tryTask.Result.Unwrap()) : AwaitUnwrap(tryTask, cancellation);
+    }
 
     /// <inheritdoc cref="Try.Unwrap{T}(Try{Try{T}})" />
     [PublicAPI, Pure]

--- a/src/AInq.Optional/Either.Extension.cs
+++ b/src/AInq.Optional/Either.Extension.cs
@@ -27,29 +27,37 @@ public static partial class Either
         /// <returns> Maybe with left value </returns>
         [PublicAPI, Pure]
         public Maybe<TLeft> MaybeLeft()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft ? Maybe<TLeft>.FromValue(either.Left) : Maybe<TLeft>.None;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasLeft ? Maybe<TLeft>.FromValue(either.Left) : Maybe<TLeft>.None;
+        }
 
         /// <summary> Get right value or none </summary>
         /// <returns> Maybe with right value </returns>
         [PublicAPI, Pure]
         public Maybe<TRight> MaybeRight()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight ? Maybe<TRight>.FromValue(either.Right) : Maybe<TRight>.None;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasRight ? Maybe<TRight>.FromValue(either.Right) : Maybe<TRight>.None;
+        }
 
         /// <summary> Try get left value </summary>
         /// <returns> Try with left value </returns>
         [PublicAPI, Pure]
         public Try<TLeft> TryLeft()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? Try<TLeft>.FromValue(either.Left)
-                : Try<TLeft>.FromError(new InvalidOperationException("No left value"));
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasLeft ? Try<TLeft>.FromValue(either.Left) : Try<TLeft>.FromError(new InvalidOperationException("No left value"));
+        }
 
         /// <summary> Try get right value </summary>
         /// <returns> Try with right value </returns>
         [PublicAPI, Pure]
         public Try<TRight> TryRight()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? Try<TRight>.FromValue(either.Right)
-                : Try<TRight>.FromError(new InvalidOperationException("No right value"));
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasRight ? Try<TRight>.FromValue(either.Right) : Try<TRight>.FromError(new InvalidOperationException("No right value"));
+        }
 
 #endregion
 
@@ -60,33 +68,44 @@ public static partial class Either
         /// <typeparam name="TLeftResult"> Left result type </typeparam>
         [PublicAPI, Pure]
         public Either<TLeftResult, TRight> SelectLeft<TLeftResult>([InstantHandle] Func<TLeft, TLeftResult> leftSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? Either<TLeftResult, TRight>.FromLeft((leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left))
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return either.HasLeft
+                ? Either<TLeftResult, TRight>.FromLeft(leftSelector.Invoke(either.Left))
                 : Either<TLeftResult, TRight>.FromRight(either.Right);
+        }
 
         /// <inheritdoc cref="SelectLeft{TLeft,TRight,TLeftResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult})" />
         [PublicAPI, Pure]
         public Either<TLeftResult, TRight> SelectLeft<TLeftResult>([InstantHandle] Func<TLeft, Either<TLeftResult, TRight>> leftSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left)
-                : Either<TLeftResult, TRight>.FromRight(either.Right);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            return either.HasLeft ? leftSelector.Invoke(either.Left) : Either<TLeftResult, TRight>.FromRight(either.Right);
+        }
 
         /// <summary> Convert to other right value type </summary>
         /// <param name="rightSelector"> Right value converter </param>
         /// <typeparam name="TRightResult"> Right result type </typeparam>
         [PublicAPI, Pure]
         public Either<TLeft, TRightResult> SelectRight<TRightResult>([InstantHandle] Func<TRight, TRightResult> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? Either<TLeft, TRightResult>.FromRight(
-                    (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right))
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasRight
+                ? Either<TLeft, TRightResult>.FromRight(rightSelector.Invoke(either.Right))
                 : Either<TLeft, TRightResult>.FromLeft(either.Left);
+        }
 
         /// <inheritdoc cref="SelectRight{TLeft,TRight,TRightResult}(Either{TLeft,TRight},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public Either<TLeft, TRightResult> SelectRight<TRightResult>([InstantHandle] Func<TRight, Either<TLeft, TRightResult>> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right)
-                : Either<TLeft, TRightResult>.FromLeft(either.Left);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasRight ? rightSelector.Invoke(either.Right) : Either<TLeft, TRightResult>.FromLeft(either.Left);
+        }
 
         /// <summary> Convert to other type </summary>
         /// <param name="leftSelector"> Left value converter </param>
@@ -96,38 +115,50 @@ public static partial class Either
         [PublicAPI, Pure]
         public Either<TLeftResult, TRightResult> Select<TLeftResult, TRightResult>([InstantHandle] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle] Func<TRight, TRightResult> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? Either<TLeftResult, TRightResult>.FromLeft(
-                    (leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left))
-                : Either<TLeftResult, TRightResult>.FromRight(
-                    (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right));
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasLeft
+                ? Either<TLeftResult, TRightResult>.FromLeft(leftSelector.Invoke(either.Left))
+                : Either<TLeftResult, TRightResult>.FromRight(rightSelector.Invoke(either.Right));
+        }
 
         /// <inheritdoc cref="Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public Either<TLeftResult, TRightResult> Select<TLeftResult, TRightResult>(
             [InstantHandle] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector, [InstantHandle] Func<TRight, TRightResult> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left)
-                : Either<TLeftResult, TRightResult>.FromRight(
-                    (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right));
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasLeft
+                ? leftSelector.Invoke(either.Left)
+                : Either<TLeftResult, TRightResult>.FromRight(rightSelector.Invoke(either.Right));
+        }
 
         /// <inheritdoc cref="Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public Either<TLeftResult, TRightResult> Select<TLeftResult, TRightResult>([InstantHandle] Func<TLeft, TLeftResult> leftSelector,
             [InstantHandle] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? Either<TLeftResult, TRightResult>.FromLeft(
-                    (leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left))
-                : (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasLeft ? Either<TLeftResult, TRightResult>.FromLeft(leftSelector.Invoke(either.Left)) : rightSelector.Invoke(either.Right);
+        }
 
         /// <inheritdoc cref="Select{TLeft,TRight,TLeftResult,TRightResult}(Either{TLeft,TRight},Func{TLeft,TLeftResult},Func{TRight,TRightResult})" />
         [PublicAPI, Pure]
         public Either<TLeftResult, TRightResult> Select<TLeftResult, TRightResult>(
             [InstantHandle] Func<TLeft, Either<TLeftResult, TRightResult>> leftSelector,
             [InstantHandle] Func<TRight, Either<TLeftResult, TRightResult>> rightSelector)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (leftSelector ?? throw new ArgumentNullException(nameof(leftSelector))).Invoke(either.Left)
-                : (rightSelector ?? throw new ArgumentNullException(nameof(rightSelector))).Invoke(either.Right);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftSelector ?? throw new ArgumentNullException(nameof(leftSelector));
+            _ = rightSelector ?? throw new ArgumentNullException(nameof(rightSelector));
+            return either.HasLeft ? leftSelector.Invoke(either.Left) : rightSelector.Invoke(either.Right);
+        }
 
 #endregion
 
@@ -136,40 +167,56 @@ public static partial class Either
         /// <summary> Get left value or default </summary>
         [PublicAPI, Pure]
         public TLeft? LeftOrDefault()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft ? either.Left : default;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasLeft ? either.Left : default;
+        }
 
         /// <summary> Get left value or default </summary>
         /// <param name="defaultValue"> Default value </param>
         [PublicAPI, Pure]
         public TLeft LeftOrDefault([NoEnumeration] TLeft defaultValue)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft ? either.Left : defaultValue;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasLeft ? either.Left : defaultValue;
+        }
 
         /// <summary> Get left value or default from generator </summary>
         /// <param name="defaultGenerator"> Default value generator </param>
         [PublicAPI, Pure]
         public TLeft LeftOrDefault([InstantHandle] Func<TLeft> defaultGenerator)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? either.Left
-                : (defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke();
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return either.HasLeft ? either.Left : defaultGenerator.Invoke();
+        }
 
         /// <summary> Get right value or default </summary>
         [PublicAPI, Pure]
         public TRight? RightOrDefault()
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight ? either.Right : default;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasRight ? either.Right : default;
+        }
 
         /// <summary> Get right value or default </summary>
         /// <param name="defaultValue"> Default value </param>
         [PublicAPI, Pure]
         public TRight RightOrDefault([NoEnumeration] TRight defaultValue)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight ? either.Right : defaultValue;
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            return either.HasRight ? either.Right : defaultValue;
+        }
 
         /// <summary> Get right value or default from generator </summary>
         /// <param name="defaultGenerator"> Default value generator </param>
         [PublicAPI, Pure]
         public TRight RightOrDefault([InstantHandle] Func<TRight> defaultGenerator)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? either.Right
-                : (defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke();
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return either.HasRight ? either.Right : defaultGenerator.Invoke();
+        }
 
 #endregion
 
@@ -179,17 +226,21 @@ public static partial class Either
         /// <param name="rightToLeft"> Right to left converter </param>
         [PublicAPI, Pure]
         public TLeft ToLeft([InstantHandle] Func<TRight, TLeft> rightToLeft)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? either.Left
-                : (rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft))).Invoke(either.Right);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightToLeft ?? throw new ArgumentNullException(nameof(rightToLeft));
+            return either.HasLeft ? either.Left : rightToLeft.Invoke(either.Right);
+        }
 
         /// <summary> Convert to right value type </summary>
         /// <param name="leftToRight"> Left to right converter </param>
         [PublicAPI, Pure]
         public TRight ToRight([InstantHandle] Func<TLeft, TRight> leftToRight)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasRight
-                ? either.Right
-                : (leftToRight ?? throw new ArgumentNullException(nameof(leftToRight))).Invoke(either.Left);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftToRight ?? throw new ArgumentNullException(nameof(leftToRight));
+            return either.HasRight ? either.Right : leftToRight.Invoke(either.Left);
+        }
 
         /// <summary> Convert to other value type </summary>
         /// <param name="fromLeft"> Left value converter </param>
@@ -197,9 +248,12 @@ public static partial class Either
         /// <typeparam name="TResult"> Left result type </typeparam>
         [PublicAPI, Pure]
         public TResult ToValue<TResult>([InstantHandle] Func<TLeft, TResult> fromLeft, [InstantHandle] Func<TRight, TResult> fromRight)
-            => (either ?? throw new ArgumentNullException(nameof(either))).HasLeft
-                ? (fromLeft ?? throw new ArgumentNullException(nameof(fromLeft))).Invoke(either.Left)
-                : (fromRight ?? throw new ArgumentNullException(nameof(fromRight))).Invoke(either.Right);
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = fromLeft ?? throw new ArgumentNullException(nameof(fromLeft));
+            _ = fromRight ?? throw new ArgumentNullException(nameof(fromRight));
+            return either.HasLeft ? fromLeft.Invoke(either.Left) : fromRight.Invoke(either.Right);
+        }
 
 #endregion
 
@@ -211,9 +265,11 @@ public static partial class Either
         [PublicAPI]
         public void Do([InstantHandle] Action<TLeft> leftAction, [InstantHandle] Action<TRight> rightAction)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                (leftAction ?? throw new ArgumentNullException(nameof(leftAction))).Invoke(either.Left);
-            else if (either.HasRight) (rightAction ?? throw new ArgumentNullException(nameof(rightAction))).Invoke(either.Right);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (either.HasLeft) leftAction.Invoke(either.Left);
+            if (either.HasRight) rightAction.Invoke(either.Right);
         }
 
         /// <summary> Do action with left or right value with additional argument </summary>
@@ -225,9 +281,11 @@ public static partial class Either
         public void Do<TArgument>([InstantHandle] Action<TLeft, TArgument> leftAction, [InstantHandle] Action<TRight, TArgument> rightAction,
             TArgument argument)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                (leftAction ?? throw new ArgumentNullException(nameof(leftAction))).Invoke(either.Left, argument);
-            else if (either.HasRight) (rightAction ?? throw new ArgumentNullException(nameof(rightAction))).Invoke(either.Right, argument);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (either.HasLeft) leftAction.Invoke(either.Left, argument);
+            if (either.HasRight) rightAction.Invoke(either.Right, argument);
         }
 
         /// <summary> Do action with left value (if exists) </summary>
@@ -235,8 +293,9 @@ public static partial class Either
         [PublicAPI]
         public void DoLeft([InstantHandle] Action<TLeft> leftAction)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                (leftAction ?? throw new ArgumentNullException(nameof(leftAction))).Invoke(either.Left);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (either.HasLeft) leftAction.Invoke(either.Left);
         }
 
         /// <summary> Do action with left value (if exists) with additional argument </summary>
@@ -246,8 +305,9 @@ public static partial class Either
         [PublicAPI]
         public void DoLeft<TArgument>([InstantHandle] Action<TLeft, TArgument> leftAction, TArgument argument)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasLeft)
-                (leftAction ?? throw new ArgumentNullException(nameof(leftAction))).Invoke(either.Left, argument);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (either.HasLeft) leftAction.Invoke(either.Left, argument);
         }
 
         /// <summary> Do action with right value (if exists) </summary>
@@ -255,8 +315,9 @@ public static partial class Either
         [PublicAPI]
         public void DoRight([InstantHandle] Action<TRight> rightAction)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasRight)
-                (rightAction ?? throw new ArgumentNullException(nameof(rightAction))).Invoke(either.Right);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (either.HasRight) rightAction.Invoke(either.Right);
         }
 
         /// <summary> Do action with right value (if exists) with additional argument </summary>
@@ -266,8 +327,9 @@ public static partial class Either
         [PublicAPI]
         public void DoRight<TArgument>([InstantHandle] Action<TRight, TArgument> rightAction, TArgument argument)
         {
-            if ((either ?? throw new ArgumentNullException(nameof(either))).HasRight)
-                (rightAction ?? throw new ArgumentNullException(nameof(rightAction))).Invoke(either.Right, argument);
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
+            if (either.HasRight) rightAction.Invoke(either.Right, argument);
         }
 
 #endregion

--- a/src/AInq.Optional/Either.Extension.cs
+++ b/src/AInq.Optional/Either.Extension.cs
@@ -269,8 +269,32 @@ public static partial class Either
             _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
             _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
             if (either.HasLeft) leftAction.Invoke(either.Left);
+            else rightAction.Invoke(either.Right);
+        }
+
+        /// <summary> Do action with left value (if exists) </summary>
+        /// <param name="leftAction"> Left value action </param>
+        [PublicAPI]
+        public void DoLeft([InstantHandle] Action<TLeft> leftAction)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
+            if (either.HasLeft) leftAction.Invoke(either.Left);
+        }
+
+        /// <summary> Do action with right value (if exists) </summary>
+        /// <param name="rightAction"> Right value action </param>
+        [PublicAPI]
+        public void DoRight([InstantHandle] Action<TRight> rightAction)
+        {
+            _ = either ?? throw new ArgumentNullException(nameof(either));
+            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
             if (either.HasRight) rightAction.Invoke(either.Right);
         }
+
+#endregion
+
+#region DoWithArgument
 
         /// <summary> Do action with left or right value with additional argument </summary>
         /// <param name="leftAction"> Left value action </param>
@@ -285,17 +309,7 @@ public static partial class Either
             _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
             _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
             if (either.HasLeft) leftAction.Invoke(either.Left, argument);
-            if (either.HasRight) rightAction.Invoke(either.Right, argument);
-        }
-
-        /// <summary> Do action with left value (if exists) </summary>
-        /// <param name="leftAction"> Left value action </param>
-        [PublicAPI]
-        public void DoLeft([InstantHandle] Action<TLeft> leftAction)
-        {
-            _ = either ?? throw new ArgumentNullException(nameof(either));
-            _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
-            if (either.HasLeft) leftAction.Invoke(either.Left);
+            else rightAction.Invoke(either.Right, argument);
         }
 
         /// <summary> Do action with left value (if exists) with additional argument </summary>
@@ -308,16 +322,6 @@ public static partial class Either
             _ = either ?? throw new ArgumentNullException(nameof(either));
             _ = leftAction ?? throw new ArgumentNullException(nameof(leftAction));
             if (either.HasLeft) leftAction.Invoke(either.Left, argument);
-        }
-
-        /// <summary> Do action with right value (if exists) </summary>
-        /// <param name="rightAction"> Right value action </param>
-        [PublicAPI]
-        public void DoRight([InstantHandle] Action<TRight> rightAction)
-        {
-            _ = either ?? throw new ArgumentNullException(nameof(either));
-            _ = rightAction ?? throw new ArgumentNullException(nameof(rightAction));
-            if (either.HasRight) rightAction.Invoke(either.Right);
         }
 
         /// <summary> Do action with right value (if exists) with additional argument </summary>

--- a/src/AInq.Optional/Either.Linq.cs
+++ b/src/AInq.Optional/Either.Linq.cs
@@ -25,13 +25,41 @@ public static partial class Either
         /// <returns> Left values collection </returns>
         [PublicAPI, LinqTunnel]
         public IEnumerable<TLeft> LeftValues()
-            => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {HasLeft: true}).Select(item => item.Left);
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(either => either is {HasLeft: true}).Select(either => either.Left);
+        }
+
+        /// <summary> Select matching left values </summary>
+        /// <param name="filter"> Filter </param>
+        /// <returns> Left values collection </returns>
+        [PublicAPI, LinqTunnel]
+        public IEnumerable<TLeft> LeftValues(Func<TLeft, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasLeft: true} && filter.Invoke(either.Left)).Select(either => either.Left);
+        }
 
         /// <summary> Select existing right values </summary>
         /// <returns> Right values collection </returns>
         [PublicAPI, LinqTunnel]
         public IEnumerable<TRight> RightValues()
-            => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {HasRight: true}).Select(item => item.Right);
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(either => either is {HasRight: true}).Select(either => either.Right);
+        }
+
+        /// <summary> Select matching right values </summary>
+        /// <param name="filter"> Filter </param>
+        /// <returns> Right values collection </returns>
+        [PublicAPI, LinqTunnel]
+        public IEnumerable<TRight> RightValues(Func<TRight, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasRight: true} && filter.Invoke(either.Right)).Select(either => either.Right);
+        }
     }
 
     /// <param name="collection"> <see cref="Either{TLeft,TRight}" /> parallel query </param>
@@ -42,11 +70,35 @@ public static partial class Either
         /// <inheritdoc cref="LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}})" />
         [PublicAPI, LinqTunnel]
         public ParallelQuery<TLeft> LeftValues()
-            => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {HasLeft: true}).Select(item => item.Left);
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(either => either is {HasLeft: true}).Select(either => either.Left);
+        }
+
+        /// <inheritdoc cref="LeftValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TLeft,bool})" />
+        [PublicAPI, LinqTunnel]
+        public ParallelQuery<TLeft> LeftValues(Func<TLeft, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasLeft: true} && filter.Invoke(either.Left)).Select(either => either.Left);
+        }
 
         /// <inheritdoc cref="RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}})" />
         [PublicAPI, LinqTunnel]
         public ParallelQuery<TRight> RightValues()
-            => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {HasRight: true}).Select(item => item.Right);
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(either => either is {HasRight: true}).Select(either => either.Right);
+        }
+
+        /// <inheritdoc cref="RightValues{TLeft,TRight}(IEnumerable{Either{TLeft,TRight}},Func{TRight,bool})" />
+        [PublicAPI, LinqTunnel]
+        public ParallelQuery<TRight> RightValues(Func<TRight, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(either => either is {HasRight: true} && filter.Invoke(either.Right)).Select(either => either.Right);
+        }
     }
 }

--- a/src/AInq.Optional/Maybe.Extension.cs
+++ b/src/AInq.Optional/Maybe.Extension.cs
@@ -182,7 +182,8 @@ public static partial class Maybe
         public Maybe<T> Or(Maybe<T> other)
         {
             _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
-            return maybe.HasValue ? maybe : other ?? throw new ArgumentNullException(nameof(other));
+            _ = other ?? throw new ArgumentNullException(nameof(other));
+            return maybe.HasValue ? maybe : other;
         }
 
         /// <summary> Get value form this item or other </summary>

--- a/src/AInq.Optional/Maybe.Extension.cs
+++ b/src/AInq.Optional/Maybe.Extension.cs
@@ -28,9 +28,10 @@ public static partial class Maybe
         /// <returns> Either </returns>
         [PublicAPI, Pure]
         public Either<T, TOther> EitherValue<TOther>([NoEnumeration] TOther other)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? Either<T, TOther>.FromLeft(maybe.Value)
-                : Either<T, TOther>.FromRight(other);
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            return maybe.HasValue ? Either<T, TOther>.FromLeft(maybe.Value) : Either<T, TOther>.FromRight(other);
+        }
 
         /// <summary> Get source value or other if empty </summary>
         /// <param name="otherGenerator"> Other generator </param>
@@ -38,16 +39,19 @@ public static partial class Maybe
         /// <returns> Either </returns>
         [PublicAPI, Pure]
         public Either<T, TOther> EitherValue<TOther>([InstantHandle] Func<TOther> otherGenerator)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? Either<T, TOther>.FromLeft(maybe.Value)
-                : Either<T, TOther>.FromRight((otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))).Invoke());
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybe.HasValue ? Either<T, TOther>.FromLeft(maybe.Value) : Either<T, TOther>.FromRight(otherGenerator.Invoke());
+        }
 
         /// <summary> Convert <see cref="Maybe{T}" /> to <see cref="Try{T}" /> </summary>
         [PublicAPI, Pure]
         public Try<T> TryValue()
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? Try<T>.FromValue(maybe.Value)
-                : Try<T>.FromError(new InvalidOperationException("No value"));
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            return maybe.HasValue ? Try<T>.FromValue(maybe.Value) : Try<T>.FromError(new InvalidOperationException("No value"));
+        }
 
 #endregion
 
@@ -58,32 +62,40 @@ public static partial class Maybe
         /// <typeparam name="TResult"> Result value type </typeparam>
         [PublicAPI, Pure]
         public Maybe<TResult> Select<TResult>([InstantHandle] Func<T, TResult> selector)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? Maybe<TResult>.FromValue((selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value))
-                : Maybe<TResult>.None;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? Maybe<TResult>.FromValue(selector.Invoke(maybe.Value)) : Maybe<TResult>.None;
+        }
 
         /// <inheritdoc cref="Select{T,TResult}(Maybe{T},Func{T,TResult})" />
         [PublicAPI, Pure]
         public Maybe<TResult> Select<TResult>([InstantHandle] Func<T, Maybe<TResult>> selector)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value)
-                : Maybe<TResult>.None;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? selector.Invoke(maybe.Value) : Maybe<TResult>.None;
+        }
 
         /// <summary> Convert to other value type or default </summary>
         /// <param name="selector"> Converter </param>
         /// <typeparam name="TResult"> Result value type </typeparam>
         [PublicAPI, Pure]
         public TResult? SelectOrDefault<TResult>([InstantHandle] Func<T, TResult> selector)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value)
-                : default;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? selector.Invoke(maybe.Value) : default;
+        }
 
         /// <inheritdoc cref="SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult})" />
         [PublicAPI, Pure]
         public TResult? SelectOrDefault<TResult>([InstantHandle] Func<T, Maybe<TResult>> selector)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value).ValueOrDefault()
-                : default;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? selector.Invoke(maybe.Value).ValueOrDefault() : default;
+        }
 
         /// <summary> Convert to other value type or default </summary>
         /// <param name="selector"> Converter </param>
@@ -91,16 +103,20 @@ public static partial class Maybe
         /// <typeparam name="TResult"> Result value type </typeparam>
         [PublicAPI, Pure]
         public TResult SelectOrDefault<TResult>([InstantHandle] Func<T, TResult> selector, [NoEnumeration] TResult defaultValue)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value)
-                : defaultValue;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? selector.Invoke(maybe.Value) : defaultValue;
+        }
 
         /// <inheritdoc cref="SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},TResult)" />
         [PublicAPI, Pure]
         public TResult SelectOrDefault<TResult>([InstantHandle] Func<T, Maybe<TResult>> selector, [NoEnumeration] TResult defaultValue)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value).ValueOrDefault(defaultValue)
-                : defaultValue;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return maybe.HasValue ? selector.Invoke(maybe.Value).ValueOrDefault(defaultValue) : defaultValue;
+        }
 
         /// <summary> Convert to other value type or default from generator </summary>
         /// <param name="selector"> Converter </param>
@@ -108,19 +124,22 @@ public static partial class Maybe
         /// <typeparam name="TResult"> Result value type </typeparam>
         [PublicAPI, Pure]
         public TResult SelectOrDefault<TResult>([InstantHandle] Func<T, TResult> selector, [InstantHandle] Func<TResult> defaultGenerator)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value)
-                : (defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke();
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybe.HasValue ? selector.Invoke(maybe.Value) : defaultGenerator.Invoke();
+        }
 
         /// <inheritdoc cref="SelectOrDefault{T,TResult}(Maybe{T},Func{T,TResult},Func{TResult})" />
         [PublicAPI, Pure]
         public TResult SelectOrDefault<TResult>([InstantHandle] Func<T, Maybe<TResult>> selector, [InstantHandle] Func<TResult> defaultGenerator)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? (selector ?? throw new ArgumentNullException(nameof(selector))).Invoke(maybe.Value)
-                                                                                 .ValueOrDefault(defaultGenerator
-                                                                                                 ?? throw new ArgumentNullException(
-                                                                                                     nameof(defaultGenerator)))
-                : (defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke();
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybe.HasValue ? selector.Invoke(maybe.Value).ValueOrDefault(defaultGenerator) : defaultGenerator.Invoke();
+        }
 
 #endregion
 
@@ -129,21 +148,29 @@ public static partial class Maybe
         /// <summary> Get value or default </summary>
         [PublicAPI, Pure]
         public T? ValueOrDefault()
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue ? maybe.Value : default;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            return maybe.HasValue ? maybe.Value : default;
+        }
 
         /// <summary> Get value or default </summary>
         /// <param name="defaultValue"> Default value </param>
         [PublicAPI, Pure]
         public T ValueOrDefault([NoEnumeration] T defaultValue)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue ? maybe.Value : defaultValue;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            return maybe.HasValue ? maybe.Value : defaultValue;
+        }
 
         /// <summary> Get value or default from generator </summary>
         /// <param name="defaultGenerator"> Default value generator </param>
         [PublicAPI, Pure]
         public T ValueOrDefault([InstantHandle] Func<T> defaultGenerator)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? maybe.Value
-                : (defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator))).Invoke();
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = defaultGenerator ?? throw new ArgumentNullException(nameof(defaultGenerator));
+            return maybe.HasValue ? maybe.Value : defaultGenerator.Invoke();
+        }
 
 #endregion
 
@@ -153,24 +180,30 @@ public static partial class Maybe
         /// <param name="other"> Other </param>
         [PublicAPI, Pure]
         public Maybe<T> Or(Maybe<T> other)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue ? maybe : other ?? throw new ArgumentNullException(nameof(other));
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            return maybe.HasValue ? maybe : other ?? throw new ArgumentNullException(nameof(other));
+        }
 
         /// <summary> Get value form this item or other </summary>
         /// <param name="otherGenerator"> Other generator </param>
         [PublicAPI, Pure]
         public Maybe<T> Or([InstantHandle] Func<Maybe<T>> otherGenerator)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-                ? maybe
-                : (otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator))).Invoke();
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = otherGenerator ?? throw new ArgumentNullException(nameof(otherGenerator));
+            return maybe.HasValue ? maybe : otherGenerator.Invoke();
+        }
 
         /// <summary> Filter value </summary>
         /// <param name="filter"> Filter </param>
         [PublicAPI, Pure]
         public Maybe<T> Filter([InstantHandle] Func<T, bool> filter)
-            => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue
-               && (filter ?? throw new ArgumentNullException(nameof(filter))).Invoke(maybe.Value)
-                ? maybe
-                : Maybe<T>.None;
+        {
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return maybe.HasValue && filter.Invoke(maybe.Value) ? maybe : Maybe<T>.None;
+        }
 
 #endregion
 
@@ -182,9 +215,11 @@ public static partial class Maybe
         [PublicAPI]
         public void Do([InstantHandle] Action<T> valueAction, [InstantHandle] Action emptyAction)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(maybe.Value);
-            else (emptyAction ?? throw new ArgumentNullException(nameof(emptyAction))).Invoke();
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybe.HasValue) valueAction.Invoke(maybe.Value);
+            else emptyAction.Invoke();
         }
 
         /// <summary> Do action with additional argument </summary>
@@ -195,9 +230,11 @@ public static partial class Maybe
         [PublicAPI]
         public void Do<TArgument>([InstantHandle] Action<T, TArgument> valueAction, [InstantHandle] Action<TArgument> emptyAction, TArgument argument)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(maybe.Value, argument);
-            else (emptyAction ?? throw new ArgumentNullException(nameof(emptyAction))).Invoke(argument);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (maybe.HasValue) valueAction.Invoke(maybe.Value, argument);
+            else emptyAction.Invoke(argument);
         }
 
         /// <summary> Do action with value (if exists) </summary>
@@ -205,8 +242,9 @@ public static partial class Maybe
         [PublicAPI]
         public void Do([InstantHandle] Action<T> valueAction)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(maybe.Value);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (maybe.HasValue) valueAction.Invoke(maybe.Value);
         }
 
         /// <summary> Do action with value (if exists) with additional argument </summary>
@@ -216,8 +254,9 @@ public static partial class Maybe
         [PublicAPI]
         public void Do<TArgument>([InstantHandle] Action<T, TArgument> valueAction, TArgument argument)
         {
-            if ((maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(maybe.Value, argument);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (maybe.HasValue) valueAction.Invoke(maybe.Value, argument);
         }
 
         /// <summary> Do action if empty </summary>
@@ -225,8 +264,9 @@ public static partial class Maybe
         [PublicAPI]
         public void DoIfEmpty([InstantHandle] Action emptyAction)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (emptyAction ?? throw new ArgumentNullException(nameof(emptyAction))).Invoke();
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybe.HasValue) emptyAction.Invoke();
         }
 
         /// <summary> Do action if empty with additional argument </summary>
@@ -236,8 +276,9 @@ public static partial class Maybe
         [PublicAPI]
         public void DoIfEmpty<TArgument>([InstantHandle] Action<TArgument> emptyAction, TArgument argument)
         {
-            if (!(maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue)
-                (emptyAction ?? throw new ArgumentNullException(nameof(emptyAction))).Invoke(argument);
+            _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+            _ = emptyAction ?? throw new ArgumentNullException(nameof(emptyAction));
+            if (!maybe.HasValue) emptyAction.Invoke(argument);
         }
 
 #endregion

--- a/src/AInq.Optional/Maybe.Linq.Alias.cs
+++ b/src/AInq.Optional/Maybe.Linq.Alias.cs
@@ -1,0 +1,124 @@
+﻿// Copyright 2021 Anton Andryushchenko
+// 
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+namespace AInq.Optional;
+
+public static partial class Maybe
+{
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IEnumerable<T> collection)
+    {
+        /// <inheritdoc cref="MaybeFirst{T}(IEnumerable{T})" />
+        [PublicAPI, Obsolete("Use MaybeFirst instead")]
+        public Maybe<T> FirstOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirst();
+        }
+
+        /// <inheritdoc cref="MaybeFirst{T}(IEnumerable{T},Func{T,bool})" />
+        [PublicAPI, Obsolete("Use MaybeFirst instead")]
+        public Maybe<T> FirstOrNone([InstantHandle] Func<T, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeFirst(filter);
+        }
+
+        /// <inheritdoc cref="MaybeLast{T}(IEnumerable{T})" />
+        [PublicAPI, Obsolete("Use MaybeLast instead")]
+        public Maybe<T> LastOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLast();
+        }
+
+        /// <inheritdoc cref="MaybeLast{T}(IEnumerable{T},Func{T,bool})" />
+        [PublicAPI, Obsolete("Use MaybeLast instead")]
+        public Maybe<T> LastOrNone([InstantHandle] Func<T, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeLast(filter);
+        }
+
+        /// <inheritdoc cref="MaybeSingle{T}(IEnumerable{T})" />
+        [PublicAPI, Obsolete("Use MaybeSingle instead")]
+        public Maybe<T> SingleOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingle();
+        }
+
+        /// <inheritdoc cref="MaybeSingle{T}(IEnumerable{T},Func{T,bool})" />
+        [PublicAPI, Obsolete("Use MaybeSingle instead")]
+        public Maybe<T> SingleOrNone([InstantHandle] Func<T, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.MaybeSingle(filter);
+        }
+    }
+
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IEnumerable<T?> collection)
+        where T : class
+    {
+        /// <inheritdoc cref="MaybeFirstNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeFirstNotNull instead")]
+        public Maybe<T> FirstNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirstNotNull();
+        }
+
+        /// <inheritdoc cref="MaybeLastNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeLastNotNull instead")]
+        public Maybe<T> LastNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLastNotNull();
+        }
+
+        /// <inheritdoc cref="MaybeSingleNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeSingleNotNull instead")]
+        public Maybe<T> SingleNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingleNotNull();
+        }
+    }
+
+    /// <param name="collection"> Value collection </param>
+    /// <typeparam name="T"> Value type </typeparam>
+    extension<T>(IEnumerable<T?> collection)
+        where T : struct
+    {
+        /// <inheritdoc cref="MaybeFirstNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeFirstNotNull instead")]
+        public Maybe<T> FirstNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeFirstNotNull();
+        }
+
+        /// <inheritdoc cref="MaybeLastNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeLastNotNull instead")]
+        public Maybe<T> LastNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeLastNotNull();
+        }
+
+        /// <inheritdoc cref="MaybeSingleNotNull{T}(IEnumerable{T?})" />
+        [PublicAPI, Obsolete("Use MaybeSingleNotNull instead")]
+        public Maybe<T> SingleNotNullOrNone()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.MaybeSingleNotNull();
+        }
+    }
+}

--- a/src/AInq.Optional/Maybe.Linq.cs
+++ b/src/AInq.Optional/Maybe.Linq.cs
@@ -70,7 +70,7 @@ public static partial class Maybe
         /// <summary> Get first value or none </summary>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> FirstOrNone()
+        public Maybe<T> MaybeFirst()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -84,7 +84,7 @@ public static partial class Maybe
         /// <param name="filter"> Filter </param>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> FirstOrNone([InstantHandle] Func<T, bool> filter)
+        public Maybe<T> MaybeFirst([InstantHandle] Func<T, bool> filter)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             _ = filter ?? throw new ArgumentNullException(nameof(filter));
@@ -98,7 +98,7 @@ public static partial class Maybe
         /// <summary> Get last value or none </summary>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> LastOrNone()
+        public Maybe<T> MaybeLast()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -112,7 +112,7 @@ public static partial class Maybe
         /// <param name="filter"> Filter </param>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> LastOrNone([InstantHandle] Func<T, bool> filter)
+        public Maybe<T> MaybeLast([InstantHandle] Func<T, bool> filter)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             _ = filter ?? throw new ArgumentNullException(nameof(filter));
@@ -127,7 +127,7 @@ public static partial class Maybe
         /// <returns> Maybe </returns>
         /// <exception cref="InvalidOperationException"> Thrown if collection contains more than one element </exception>
         [PublicAPI]
-        public Maybe<T> SingleOrNone()
+        public Maybe<T> MaybeSingle()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -142,7 +142,7 @@ public static partial class Maybe
         /// <returns> Maybe </returns>
         /// <exception cref="InvalidOperationException"> Thrown if collection contains more than one matching element </exception>
         [PublicAPI]
-        public Maybe<T> SingleOrNone([InstantHandle] Func<T, bool> filter)
+        public Maybe<T> MaybeSingle([InstantHandle] Func<T, bool> filter)
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
             _ = filter ?? throw new ArgumentNullException(nameof(filter));
@@ -162,7 +162,7 @@ public static partial class Maybe
         /// <summary> Get first not null value or none </summary>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> FirstNotNullOrNone()
+        public Maybe<T> MaybeFirstNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -175,7 +175,7 @@ public static partial class Maybe
         /// <summary> Get last not null value or none </summary>
         /// <returns> Maybe </returns>
         [PublicAPI]
-        public Maybe<T> LastNotNullOrNone()
+        public Maybe<T> MaybeLastNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -189,7 +189,7 @@ public static partial class Maybe
         /// <returns> Maybe </returns>
         /// <exception cref="InvalidOperationException"> Thrown if collection contains more than one not null element </exception>
         [PublicAPI]
-        public Maybe<T> SingleNotNullOrNone()
+        public Maybe<T> MaybeSingleNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -205,9 +205,9 @@ public static partial class Maybe
     extension<T>(IEnumerable<T?> collection)
         where T : struct
     {
-        /// <inheritdoc cref="FirstNotNullOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="MaybeFirstNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public Maybe<T> FirstNotNullOrNone()
+        public Maybe<T> MaybeFirstNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -217,10 +217,9 @@ public static partial class Maybe
 #endif
         }
 
-        /// <summary> Get last not null value or none </summary>
-        /// <returns> Maybe </returns>
+        /// <inheritdoc cref="MaybeLastNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public Maybe<T> LastNotNullOrNone()
+        public Maybe<T> MaybeLastNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD
@@ -230,9 +229,9 @@ public static partial class Maybe
 #endif
         }
 
-        /// <inheritdoc cref="SingleNotNullOrNone{T}(IEnumerable{T})" />
+        /// <inheritdoc cref="MaybeSingleNotNull{T}(IEnumerable{T?})" />
         [PublicAPI]
-        public Maybe<T> SingleNotNullOrNone()
+        public Maybe<T> MaybeSingleNotNull()
         {
             _ = collection ?? throw new ArgumentNullException(nameof(collection));
 #if NETSTANDARD

--- a/src/AInq.Optional/Maybe.cs
+++ b/src/AInq.Optional/Maybe.cs
@@ -63,5 +63,8 @@ public static partial class Maybe
     /// <typeparam name="T"> Value type </typeparam>
     [PublicAPI, Pure]
     public static Maybe<T> Unwrap<T>(this Maybe<Maybe<T>> maybe)
-        => (maybe ?? throw new ArgumentNullException(nameof(maybe))).HasValue ? maybe.Value : None<T>();
+    {
+        _ = maybe ?? throw new ArgumentNullException(nameof(maybe));
+        return maybe.HasValue ? maybe.Value : None<T>();
+    }
 }

--- a/src/AInq.Optional/Try.Extension.cs
+++ b/src/AInq.Optional/Try.Extension.cs
@@ -41,16 +41,20 @@ public static partial class Try
         /// <typeparam name="TResult"> Result value type </typeparam>
         [PublicAPI, Pure]
         public Try<TResult> Select<TResult>([InstantHandle] Func<T, TResult> selector)
-            => !(@try ?? throw new ArgumentNullException(nameof(@try))).Success
-                ? Try<TResult>.ConvertError(@try)
-                : Result(selector ?? throw new ArgumentNullException(nameof(selector)), @try.Value);
+        {
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return !@try.Success ? Try<TResult>.ConvertError(@try) : Result(selector, @try.Value);
+        }
 
         /// <inheritdoc cref="Select{T,TResult}(Try{T},Func{T,TResult})" />
         [PublicAPI, Pure]
         public Try<TResult> Select<TResult>([InstantHandle] Func<T, Try<TResult>> selector)
-            => !(@try ?? throw new ArgumentNullException(nameof(@try))).Success
-                ? Try<TResult>.ConvertError(@try)
-                : Result(selector ?? throw new ArgumentNullException(nameof(selector)), @try.Value).Unwrap();
+        {
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
+            return !@try.Success ? Try<TResult>.ConvertError(@try) : Result(selector, @try.Value).Unwrap();
+        }
 
 #endregion
 
@@ -62,8 +66,10 @@ public static partial class Try
         [PublicAPI]
         public void Do([InstantHandle] Action<T> valueAction, [InstantHandle] Action<Exception> errorAction)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(@try.Value);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (@try.Success) valueAction.Invoke(@try.Value);
             else
                 try
                 {
@@ -71,7 +77,7 @@ public static partial class Try
                 }
                 catch (Exception exception)
                 {
-                    (errorAction ?? throw new ArgumentNullException(nameof(errorAction))).Invoke(exception);
+                    errorAction.Invoke(exception);
                 }
         }
 
@@ -83,8 +89,10 @@ public static partial class Try
         [PublicAPI]
         public void Do<TArgument>([InstantHandle] Action<T, TArgument> valueAction, [InstantHandle] Action<Exception> errorAction, TArgument argument)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(@try.Value, argument);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (@try.Success) valueAction.Invoke(@try.Value, argument);
             else
                 try
                 {
@@ -92,7 +100,7 @@ public static partial class Try
                 }
                 catch (Exception exception)
                 {
-                    (errorAction ?? throw new ArgumentNullException(nameof(errorAction))).Invoke(exception);
+                    errorAction.Invoke(exception);
                 }
         }
 
@@ -102,8 +110,9 @@ public static partial class Try
         [PublicAPI]
         public void Do([InstantHandle] Action<T> valueAction, bool throwIfError = false)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(@try.Value);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (@try.Success) valueAction.Invoke(@try.Value);
             else if (throwIfError) @try.Throw();
         }
 
@@ -115,8 +124,9 @@ public static partial class Try
         [PublicAPI]
         public void Do<TArgument>([InstantHandle] Action<T, TArgument> valueAction, TArgument argument, bool throwIfError = false)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success)
-                (valueAction ?? throw new ArgumentNullException(nameof(valueAction))).Invoke(@try.Value, argument);
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = valueAction ?? throw new ArgumentNullException(nameof(valueAction));
+            if (@try.Success) valueAction.Invoke(@try.Value, argument);
             else if (throwIfError) @try.Throw();
         }
 
@@ -125,14 +135,16 @@ public static partial class Try
         [PublicAPI]
         public void DoIfError([InstantHandle] Action<Exception> errorAction)
         {
-            if ((@try ?? throw new ArgumentNullException(nameof(@try))).Success) return;
+            _ = @try ?? throw new ArgumentNullException(nameof(@try));
+            _ = errorAction ?? throw new ArgumentNullException(nameof(errorAction));
+            if (@try.Success) return;
             try
             {
                 @try.Throw();
             }
             catch (Exception exception)
             {
-                (errorAction ?? throw new ArgumentNullException(nameof(errorAction))).Invoke(exception);
+                errorAction.Invoke(exception);
             }
         }
 

--- a/src/AInq.Optional/Try.Linq.cs
+++ b/src/AInq.Optional/Try.Linq.cs
@@ -16,16 +16,48 @@ namespace AInq.Optional;
 
 public static partial class Try
 {
-    /// <summary> Select existing values </summary>
     /// <param name="collection"> Try collection </param>
     /// <typeparam name="T"> Value type </typeparam>
-    /// <returns> Values collection </returns>
-    [PublicAPI, LinqTunnel]
-    public static IEnumerable<T> Values<T>(this IEnumerable<Try<T>> collection)
-        => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {Success: true}).Select(item => item.Value);
+    extension<T>(IEnumerable<Try<T>> collection)
+    {
+        /// <summary> Select existing values </summary>
+        /// <returns> Values collection </returns>
+        [PublicAPI, LinqTunnel]
+        public IEnumerable<T> Values()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(@try => @try is {Success: true}).Select(@try => @try.Value);
+        }
 
-    /// <inheritdoc cref="Values{T}(IEnumerable{Try{T}})" />
-    [PublicAPI, LinqTunnel]
-    public static ParallelQuery<T> Values<T>(this ParallelQuery<Try<T>> collection)
-        => (collection ?? throw new ArgumentNullException(nameof(collection))).Where(item => item is {Success: true}).Select(item => item.Value);
+        /// <summary> Select existing matching values </summary>
+        /// <param name="filter"> Filter </param>
+        /// <returns> Values collection </returns>
+        [PublicAPI, LinqTunnel]
+        public IEnumerable<T> Values([InstantHandle] Func<T, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(@try => @try is {Success: true} && filter.Invoke(@try.Value)).Select(@try => @try.Value);
+        }
+    }
+
+    extension<T>(ParallelQuery<Try<T>> collection)
+    {
+        /// <inheritdoc cref="Values{T}(IEnumerable{Try{T}})" />
+        [PublicAPI, LinqTunnel]
+        public ParallelQuery<T> Values()
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            return collection.Where(@try => @try is {Success: true}).Select(@try => @try.Value);
+        }
+
+        /// <inheritdoc cref="Values{T}(IEnumerable{Try{T}},Func{T,bool})" />
+        [PublicAPI, LinqTunnel]
+        public ParallelQuery<T> Values([InstantHandle] Func<T, bool> filter)
+        {
+            _ = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ = filter ?? throw new ArgumentNullException(nameof(filter));
+            return collection.Where(@try => @try is {Success: true} && filter.Invoke(@try.Value)).Select(@try => @try.Value);
+        }
+    }
 }

--- a/src/AInq.Optional/Try.cs
+++ b/src/AInq.Optional/Try.cs
@@ -78,5 +78,8 @@ public static partial class Try
     /// <typeparam name="T"> Value type </typeparam>
     [PublicAPI, Pure]
     public static Try<T> Unwrap<T>(this Try<Try<T>> @try)
-        => (@try ?? throw new ArgumentNullException(nameof(@try))).Success ? @try.Value : Try<T>.ConvertError(@try);
+    {
+        _ = @try ?? throw new ArgumentNullException(nameof(@try));
+        return @try.Success ? @try.Value : Try<T>.ConvertError(@try);
+    }
 }


### PR DESCRIPTION
[IMP] Some Maybe LINQ extensions renamed to avoid ambiguity with other libs. Current method names saved as aliases and marked as deprecated.
[REF] Internal null-check refactoring